### PR TITLE
Build the Windows executable without publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,25 +11,7 @@ on:
 
 jobs:
   windows-exe:
-    # Built on Windows because that is where it will be run: the EFI is almost
-    # always prepared from the machine being converted, and that machine has no
-    # Python on it.
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: pip install pyinstaller
-      - run: pyinstaller --clean --noconfirm --distpath dist tools/pyinstaller.spec
-      - name: It builds an EFI from the bundle alone
-        run: |
-          dist/HackintoshEFIBuilder.exe --no-detect --answers 2,10,3 --out smoke/EFI
-          if (-not (Test-Path smoke/EFI/OC/config.plist)) { exit 1 }
-      - uses: actions/upload-artifact@v4
-        with:
-          name: windows-exe
-          path: dist/HackintoshEFIBuilder.exe
+    uses: ./.github/workflows/windows-exe.yml
 
   build:
     needs: windows-exe

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -1,0 +1,38 @@
+name: windows-exe
+
+# Builds the guided builder into a single Windows executable.
+#
+# Separate from the release so it can be run on its own: the executable can be
+# downloaded from the run's artifacts and tried on a real machine before any tag
+# exists. release.yml calls this same workflow, so what gets published is what
+# was tested rather than a second build of it.
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    # Built on Windows because that is where it runs: the EFI is almost always
+    # prepared from the machine being converted, and that machine has no Python.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pyinstaller
+      - run: pyinstaller --clean --noconfirm --distpath dist tools/pyinstaller.spec
+
+      - name: It builds an EFI from the bundle alone
+        run: |
+          dist/HackintoshEFIBuilder.exe --no-detect --answers 2,10,3 --out smoke/EFI
+          if (-not (Test-Path smoke/EFI/OC/config.plist)) { exit 1 }
+
+      - name: And detection runs without throwing
+        run: dist/HackintoshEFIBuilder.exe --answers 2,10,3 --out smoke2/EFI
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-exe
+          path: dist/HackintoshEFIBuilder.exe

--- a/tools/README.md
+++ b/tools/README.md
@@ -301,8 +301,12 @@ data files, `EFI/` and `vendor/` into it, and `setup.py` chdirs into the
 unpacked bundle at startup. The frozen build therefore runs the same code down
 the same paths as a checkout, with no second branch to keep working.
 
-It is built on a Windows runner by `.github/workflows/release.yml`, which then
-makes it build an EFI from the bundle alone before the release is published.
+`.github/workflows/windows-exe.yml` builds it and can be run on its own from the
+Actions tab, which puts the executable in the run's artifacts - so it can be
+tried on a real machine before any tag exists. `release.yml` calls that same
+workflow rather than repeating it, so what gets published is the build that was
+tested. Either way it has to produce an EFI from its own bundle before the run
+is allowed to pass.
 
 `--answers 2,10,3` replays a menu run non-interactively. That is what CI uses,
 on both platforms, instead of piping keystrokes.


### PR DESCRIPTION
The exe build only existed inside `release.yml`, so the only way to get one was to publish a release - which meant the first executable anybody downloaded would also be the first one ever built.

It is now `.github/workflows/windows-exe.yml`, runnable on its own from the Actions tab, with the executable in the run's artifacts. `release.yml` calls that workflow rather than repeating it, so what gets published is the build that was tested.

The run also has to produce an EFI from its own bundle, and now runs detection once too, before it is allowed to pass.