### PR TITLE
Read graphics from the bus, not the adapter list

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,16 @@ jobs:
           python3 tools/setup.py --answers 2,10,3 --out /tmp/setup-laptop/EFI
           python3 tools/setup.py --answers 1,2,2,3,6 --out /tmp/setup-amd/EFI
           python3 tools/detect.py
+          python3 -c "
+import sys; sys.path.insert(0,'tools'); import detect
+real, virt = detect.split_graphics([
+    r'PCI\\VEN_8086&DEV_E20B&SUBSYS_1&REV_08\\6&a&0|Intel(R) Arc(TM) B580 Graphics',
+    r'ROOT\\DISPLAY\\0000|Virtual Display Driver'])
+assert [g['name'] for g in real] == ['Intel(R) Arc(TM) B580 Graphics'], real
+assert real[0]['id'] == '8086:e20b', real
+assert [g['name'] for g in virt] == ['Virtual Display Driver'], virt
+print('  graphics split ok')
+"
           python3 tools/advise.py --ids 8086:15b8,8086:2723 --usb-ids 8087:0029
           python3 tools/advise.py --ids 10ec:c822
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -97,6 +97,14 @@ PowerShell CIM on Windows, `lspci` and sysfs on Linux, `system_profiler` and
 `sysctl` on macOS - so it needs no dependencies and no admin rights. Run it on
 its own to see what it found.
 
+Graphics is read from the bus, not from the adapter list. Windows counts every
+display adapter as a video controller, including the virtual ones a remote
+desktop or dummy-monitor tool installs, and those can outnumber and outrank the
+real card - a machine with an Arc B580 reported a virtual driver instead.
+Adapters that enumerate under `ROOT` rather than `PCI` are therefore set aside,
+and named as ignored rather than dropped quietly, so someone who installed one
+can see it was recognised.
+
 Its CPU rule stays quiet unless it is sure. A four-digit Intel SKU normally
 names its generation with the first digit, so 2600K is 2nd generation; Ice Lake
 mobile breaks that, and 1065G7 is 10th. 10th generation mobile then covers two

--- a/tools/detect.py
+++ b/tools/detect.py
@@ -121,9 +121,13 @@ def _windows():
     if types:
         # 8-14 and 30-32 are the portable chassis codes in the DMTF table
         out['laptop'] = bool(types & {8, 9, 10, 11, 12, 14, 18, 21, 30, 31, 32})
+    # Win32_VideoController lists every display adapter, including virtual ones
+    # a remote desktop or a dummy-monitor tool installs. Those enumerate under
+    # ROOT rather than PCI, so the bus is what separates the graphics card from
+    # a driver pretending to be one.
     out['gpu'] = [l.strip() for l in
-                  _ps('Get-CimInstance Win32_VideoController | '
-                      'ForEach-Object { $_.Name }').splitlines() if l.strip()]
+                  _ps('Get-CimInstance Win32_VideoController | ForEach-Object '
+                      '{ "$($_.PNPDeviceID)|$($_.Name)" }').splitlines() if l.strip()]
     out['pci'] = _ps(
         'Get-CimInstance Win32_PnPEntity | Where-Object { $_.PNPDeviceID -like "PCI*" } | '
         'ForEach-Object { "$($_.PNPDeviceID)|$($_.Name)" }')
@@ -145,7 +149,7 @@ def _linux():
     if chassis.isdigit():
         out['laptop'] = int(chassis) in {8, 9, 10, 11, 12, 14, 18, 21, 30, 31, 32}
     out['pci'] = _run(['lspci', '-nn'])
-    out['gpu'] = [l.split(': ', 1)[-1] for l in out['pci'].splitlines()
+    out['gpu'] = [f"PCI|{l.split(': ', 1)[-1]}" for l in out['pci'].splitlines()
                   if 'VGA compatible controller' in l or '3D controller' in l]
     out['usb'] = _run(['lsusb'])
     return out
@@ -162,7 +166,7 @@ def _macos():
     out['vendor'] = ''
     out['pci'] = _run(['system_profiler', 'SPPCIDataType'])
     out['usb'] = _run(['system_profiler', 'SPUSBDataType'])
-    out['gpu'] = [m.strip() for m in re.findall(
+    out['gpu'] = [f'PCI|{m.strip()}' for m in re.findall(
         r'^\s*Chipset Model:\s*(.+)$',
         _run(['system_profiler', 'SPDisplaysDataType']), re.M)]
     return out
@@ -205,6 +209,26 @@ def _apple_pairs(text, vendor_key, device_key):
     return out
 
 
+def split_graphics(entries):
+    """(real graphics cards, virtual adapters) from "bus-or-id|name" strings.
+
+    Reporting a virtual adapter as the graphics card is worse than reporting
+    nothing: it is the kind of wrong answer that looks right, and someone would
+    configure an EFI around it."""
+    real, virtual = [], []
+    for e in entries or []:
+        ident, _, name = e.partition('|')
+        name = (name or ident).strip()
+        if not name:
+            continue
+        pci = _pairs(e, PCI_PATTERNS)   # the id may sit in either half
+        if ident.upper().startswith('PCI') or pci:
+            real.append({'name': name, 'id': next(iter(sorted(pci)), None)})
+        else:
+            virtual.append({'name': name, 'id': None})
+    return real, virtual
+
+
 def probe():
     """Everything the machine will tell us, with the gaps left as None."""
     system = platform.system()
@@ -218,7 +242,9 @@ def probe():
         'laptop': laptop,
         'oem': normalise_oem(raw.get('vendor')),
         'oem_raw': (raw.get('vendor') or '').strip() or None,
-        'gpu': raw.get('gpu') or [],
+        'gpu': [g['name'] for g in split_graphics(raw.get('gpu'))[0]],
+        'gpu_devices': split_graphics(raw.get('gpu'))[0],
+        'gpu_virtual': [g['name'] for g in split_graphics(raw.get('gpu'))[1]],
         'pci': raw.get('pci') or '',
         'pci_ids': sorted(_pairs(raw.get('pci'), PCI_PATTERNS)
                           | (_apple_pairs(raw.get('pci'), 'Vendor ID', 'Device ID')
@@ -234,6 +260,9 @@ if __name__ == '__main__':
     for k, v in probe().items():
         if k == 'pci':
             print(f'  {k:10s} {len(v.splitlines())} lines')
+        elif k in ('gpu_devices',):
+            for g in v:
+                print(f'  {k:10s} {g["name"]}' + (f'  [{g["id"]}]' if g['id'] else ''))
         elif k in ('pci_ids', 'usb_ids'):
             print(f'  {k:10s} {len(v)}: ' + ', '.join(v[:8]) + (' ...' if len(v) > 8 else ''))
         else:

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -152,8 +152,14 @@ def main():
         print(f'  {DIM}this machine:{RESET} {hw["cpu"]}'
               + (f', {hw["cores"]} cores' if hw.get('cores') else '')
               + (f', {hw["oem_raw"]}' if hw.get('oem_raw') else ''))
-        if hw.get('gpu'):
-            print(f'  {DIM}graphics:{RESET}     {", ".join(hw["gpu"][:2])}')
+        for g in hw.get('gpu_devices', [])[:3]:
+            print(f'  {DIM}graphics:{RESET}     {g["name"]}'
+                  + (f'  {DIM}[{g["id"]}]{RESET}' if g.get('id') else ''))
+        if hw.get('gpu_virtual'):
+            # named rather than dropped silently: someone who installed one of
+            # these should see that it was recognised and set aside
+            print(f'  {DIM}ignored:{RESET}      {", ".join(hw["gpu_virtual"])}'
+                  f'  {DIM}(virtual display adapters, not graphics hardware){RESET}')
     elif not a.no_detect:
         print(f'  {DIM}could not read this machine; every question is still answerable{RESET}')
 


### PR DESCRIPTION
A machine with an Intel Arc B580 reported a virtual display driver as its graphics card.

Windows counts every display adapter as a video controller, including the virtual ones a remote desktop or dummy-monitor tool installs, and those can outrank the real card in that list. Adapters that enumerate under `ROOT` rather than `PCI` are now set aside.

The PCI id is carried next to the name so the answer can be checked - `Intel(R) Arc(TM) B580 Graphics [8086:e20b]` rather than just a string. Ignored adapters are named rather than dropped quietly, since someone who installed one should see that it was recognised and why it was not used.

CI asserts the split on the exact case that was wrong.