### PR TITLE
Ask which machine the EFI is for

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -60,7 +60,8 @@ jobs:
         run: |
           chmod +x vendor/opencore/*/Utilities/*/*.linux
           python3 tools/selftest.py
-          python3 tools/setup.py --hda-ids 10ec:0255 --answers 1,2,10,3 --out /tmp/refresh/EFI
+          python3 tools/setup.py --machine tools/fixtures/no-hardware.json \
+            --hda-ids 10ec:0255 --answers 2,10,3 --out /tmp/refresh/EFI
 
       - name: Open a pull request
         if: steps.diff.outputs.changed == 'yes'

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           chmod +x vendor/opencore/*/Utilities/*/*.linux
           python3 tools/selftest.py
-          python3 tools/setup.py --hda-ids 10ec:0255 --answers 2,10,3 --out /tmp/refresh/EFI
+          python3 tools/setup.py --hda-ids 10ec:0255 --answers 1,2,10,3 --out /tmp/refresh/EFI
 
       - name: Open a pull request
         if: steps.diff.outputs.changed == 'yes'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,47 +30,62 @@ jobs:
 
       - name: Representative builds come out clean
         run: |
-          python3 tools/setup.py --answers 1,2,10,3 --out /tmp/laptop/EFI
-          python3 tools/setup.py --answers 1,2,2,3,6 --out /tmp/amd/EFI
+          # NONE starts from a report describing no hardware, so the questions
+          # are the same on every runner. Detecting the runner instead makes the
+          # answer string depend on whether it happens to have an NVMe drive.
+          NONE='--machine tools/fixtures/no-hardware.json'
+          python3 tools/setup.py $NONE --answers 2,10,3 --out /tmp/laptop/EFI
+          python3 tools/setup.py $NONE --answers 1,2,2,3,6 --out /tmp/amd/EFI
           python3 tools/build.py --name 'Desktop/Intel/016 - Desktop - Raptor Lake' --out /tmp/named/EFI
+          # and once against this runner, declining whatever it turns out to have
+          python3 tools/setup.py --answers 1,2,10,3,3 --out /tmp/local/EFI
 
       - name: Storage advice
         run: |
-          python3 tools/setup.py --nvme 'Samsung SSD 970 EVO' --answers 1,2,10,3,1 --out /tmp/nvme/EFI
-          python3 tools/setup.py --nvme 'APPLE SSD AP0512'    --answers 1,2,10,3   --out /tmp/apple-nvme/EFI
+          NONE='--machine tools/fixtures/no-hardware.json'
+          python3 tools/setup.py $NONE --nvme 'Samsung SSD 970 EVO' --answers 2,10,3,1 --out /tmp/nvme/EFI
+          test -d /tmp/nvme/EFI/OC/Kexts/NVMeFix.kext
+          python3 tools/setup.py $NONE --nvme 'APPLE SSD AP0512'    --answers 2,10,3   --out /tmp/apple-nvme/EFI
+          test ! -d /tmp/apple-nvme/EFI/OC/Kexts/NVMeFix.kext
 
       - name: Network kexts, both modes and declining
         run: |
-          IDS='--ids 8086:15b8 --usb-ids 8087:0029'
-          python3 tools/setup.py $IDS --answers 1,2,10,3,1    --out /tmp/net-all/EFI
-          python3 tools/setup.py $IDS --answers 1,2,10,3,2,10 --out /tmp/net-sonoma/EFI
-          python3 tools/setup.py $IDS --answers 1,2,10,3,3    --out /tmp/net-none/EFI
+          IDS='--machine tools/fixtures/no-hardware.json --ids 8086:15b8 --usb-ids 8087:0029'
+          python3 tools/setup.py $IDS --answers 2,10,3,1    --out /tmp/net-all/EFI
+          python3 tools/setup.py $IDS --answers 2,10,3,2,10 --out /tmp/net-sonoma/EFI
+          python3 tools/setup.py $IDS --answers 2,10,3,3    --out /tmp/net-none/EFI
+          test -d /tmp/net-all/EFI/OC/Kexts/IntelMausi.kext
+          test ! -d /tmp/net-none/EFI/OC/Kexts/IntelMausi.kext
 
       - name: Wi-Fi resolves to one build, or to none
         run: |
-          python3 tools/setup.py --ids 8086:2723 --answers 1,2,10,3,2,10 --out /tmp/wifi-sonoma/EFI
+          NONE='--machine tools/fixtures/no-hardware.json'
+          python3 tools/setup.py $NONE --ids 8086:2723 --answers 2,10,3,2,10 --out /tmp/wifi-sonoma/EFI
           test -d /tmp/wifi-sonoma/EFI/OC/Kexts/AirportItlwm.kext
-          python3 tools/setup.py --ids 8086:2723 --answers 1,2,10,3,2,11 --out /tmp/wifi-sequoia/EFI
+          python3 tools/setup.py $NONE --ids 8086:2723 --answers 2,10,3,2,11 --out /tmp/wifi-sequoia/EFI
           test ! -d /tmp/wifi-sequoia/EFI/OC/Kexts/AirportItlwm.kext
           python3 tools/itlwm.py
 
       - name: Trackpad, framebuffer and a user-made USB map
         run: |
-          python3 tools/setup.py --ids 8086:9d60 --answers 1,2,10,3,1 --out /tmp/i2c/EFI
-          python3 tools/setup.py --ids 8086:5912 --answers 1,2,10,3   --out /tmp/fb/EFI
+          NONE='--machine tools/fixtures/no-hardware.json'
+          python3 tools/setup.py $NONE --ids 8086:9d60 --answers 2,10,3,1 --out /tmp/i2c/EFI
+          python3 tools/setup.py $NONE --ids 8086:5912 --answers 2,10,3   --out /tmp/fb/EFI
           cp -r EFI/OC/Kexts/UTBDefault.kext /tmp/UTBMap.kext
-          python3 tools/setup.py --ids 8086:2723 --usb-map /tmp/UTBMap.kext \
-            --answers 1,2,10,3,2,10 --out /tmp/usbmap/EFI
+          python3 tools/setup.py $NONE --ids 8086:2723 --usb-map /tmp/UTBMap.kext \
+            --answers 2,10,3,2,10 --out /tmp/usbmap/EFI
           test -d /tmp/usbmap/EFI/OC/Kexts/UTBMap.kext
           test ! -d /tmp/usbmap/EFI/OC/Kexts/UTBDefault.kext
 
       - name: Building for a machine that is not this one
         run: |
+          # a real round trip: this runner's own hardware, written out and read
+          # back. The trailing 3 declines whatever it has, since that varies.
           python3 tools/detect.py --report /tmp/machine.json
-          python3 tools/setup.py --machine /tmp/machine.json --answers 2,10,3 \
+          python3 tools/setup.py --machine /tmp/machine.json --answers 2,10,3,3 \
             --out /tmp/from-report/EFI
           # menu route: 2 picks the report, then its path, then the usual answers
-          python3 tools/setup.py --answers 2,/tmp/machine.json,2,10,3 --out /tmp/menu-report/EFI
+          python3 tools/setup.py --answers 2,/tmp/machine.json,2,10,3,3 --out /tmp/menu-report/EFI
           # 3 is the other machine with no report: network hardware is named,
           # here Intel Ethernet, no Wi-Fi, Intel Bluetooth, for every macOS
           python3 tools/setup.py --answers 3,2,10,3,1,2,1,1 --out /tmp/by-name/EFI

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,39 +30,53 @@ jobs:
 
       - name: Representative builds come out clean
         run: |
-          python3 tools/setup.py --answers 2,10,3 --out /tmp/laptop/EFI
+          python3 tools/setup.py --answers 1,2,10,3 --out /tmp/laptop/EFI
           python3 tools/setup.py --answers 1,2,2,3,6 --out /tmp/amd/EFI
           python3 tools/build.py --name 'Desktop/Intel/016 - Desktop - Raptor Lake' --out /tmp/named/EFI
 
       - name: Storage advice
         run: |
-          python3 tools/setup.py --nvme 'Samsung SSD 970 EVO' --answers 2,10,3,1 --out /tmp/nvme/EFI
-          python3 tools/setup.py --nvme 'APPLE SSD AP0512'    --answers 2,10,3   --out /tmp/apple-nvme/EFI
+          python3 tools/setup.py --nvme 'Samsung SSD 970 EVO' --answers 1,2,10,3,1 --out /tmp/nvme/EFI
+          python3 tools/setup.py --nvme 'APPLE SSD AP0512'    --answers 1,2,10,3   --out /tmp/apple-nvme/EFI
 
       - name: Network kexts, both modes and declining
         run: |
           IDS='--ids 8086:15b8 --usb-ids 8087:0029'
-          python3 tools/setup.py $IDS --answers 2,10,3,1    --out /tmp/net-all/EFI
-          python3 tools/setup.py $IDS --answers 2,10,3,2,10 --out /tmp/net-sonoma/EFI
-          python3 tools/setup.py $IDS --answers 2,10,3,3    --out /tmp/net-none/EFI
+          python3 tools/setup.py $IDS --answers 1,2,10,3,1    --out /tmp/net-all/EFI
+          python3 tools/setup.py $IDS --answers 1,2,10,3,2,10 --out /tmp/net-sonoma/EFI
+          python3 tools/setup.py $IDS --answers 1,2,10,3,3    --out /tmp/net-none/EFI
 
       - name: Wi-Fi resolves to one build, or to none
         run: |
-          python3 tools/setup.py --ids 8086:2723 --answers 2,10,3,2,10 --out /tmp/wifi-sonoma/EFI
+          python3 tools/setup.py --ids 8086:2723 --answers 1,2,10,3,2,10 --out /tmp/wifi-sonoma/EFI
           test -d /tmp/wifi-sonoma/EFI/OC/Kexts/AirportItlwm.kext
-          python3 tools/setup.py --ids 8086:2723 --answers 2,10,3,2,11 --out /tmp/wifi-sequoia/EFI
+          python3 tools/setup.py --ids 8086:2723 --answers 1,2,10,3,2,11 --out /tmp/wifi-sequoia/EFI
           test ! -d /tmp/wifi-sequoia/EFI/OC/Kexts/AirportItlwm.kext
           python3 tools/itlwm.py
 
       - name: Trackpad, framebuffer and a user-made USB map
         run: |
-          python3 tools/setup.py --ids 8086:9d60 --answers 2,10,3,1 --out /tmp/i2c/EFI
-          python3 tools/setup.py --ids 8086:5912 --answers 2,10,3   --out /tmp/fb/EFI
+          python3 tools/setup.py --ids 8086:9d60 --answers 1,2,10,3,1 --out /tmp/i2c/EFI
+          python3 tools/setup.py --ids 8086:5912 --answers 1,2,10,3   --out /tmp/fb/EFI
           cp -r EFI/OC/Kexts/UTBDefault.kext /tmp/UTBMap.kext
           python3 tools/setup.py --ids 8086:2723 --usb-map /tmp/UTBMap.kext \
-            --answers 2,10,3,2,10 --out /tmp/usbmap/EFI
+            --answers 1,2,10,3,2,10 --out /tmp/usbmap/EFI
           test -d /tmp/usbmap/EFI/OC/Kexts/UTBMap.kext
           test ! -d /tmp/usbmap/EFI/OC/Kexts/UTBDefault.kext
+
+      - name: Building for a machine that is not this one
+        run: |
+          python3 tools/detect.py --report /tmp/machine.json
+          python3 tools/setup.py --machine /tmp/machine.json --answers 2,10,3 \
+            --out /tmp/from-report/EFI
+          # menu route: 2 picks the report, then its path, then the usual answers
+          python3 tools/setup.py --answers 2,/tmp/machine.json,2,10,3 --out /tmp/menu-report/EFI
+          # 3 is the other machine with no report: network hardware is named,
+          # here Intel Ethernet, no Wi-Fi, Intel Bluetooth, for every macOS
+          python3 tools/setup.py --answers 3,2,10,3,1,2,1,1 --out /tmp/by-name/EFI
+          test -d /tmp/by-name/EFI/OC/Kexts/IntelMausi.kext
+          test -d /tmp/by-name/EFI/OC/Kexts/IntelBluetoothFirmware.kext
+          test ! -d /tmp/by-name/EFI/OC/Kexts/AirportItlwm.kext
 
       - name: Detection and advice run standalone
         run: |

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -30,7 +30,7 @@ jobs:
           if (-not (Test-Path smoke/EFI/OC/config.plist)) { exit 1 }
 
       - name: And detection runs without throwing
-        run: dist/HackintoshEFIBuilder.exe --answers 1,2,10,3 --out smoke2/EFI
+        run: dist/HackintoshEFIBuilder.exe --answers 1,2,10,3,3 --out smoke2/EFI
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -30,7 +30,7 @@ jobs:
           if (-not (Test-Path smoke/EFI/OC/config.plist)) { exit 1 }
 
       - name: And detection runs without throwing
-        run: dist/HackintoshEFIBuilder.exe --answers 2,10,3 --out smoke2/EFI
+        run: dist/HackintoshEFIBuilder.exe --answers 1,2,10,3 --out smoke2/EFI
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you hit a problem, open an issue with what you have and what happened.
 ## Table of contents
 
 - [Get your EFI](#get-your-efi)
+- [Building for another machine](#building-for-another-machine)
 - [Check Compatibility](#check-compatibility)
 - [Download macOS Image](#download-macos-image)
 - [Write macOS Image](#write-macos-image)
@@ -43,23 +44,35 @@ for you - detection can be wrong, and a wrong answer that arrives already ticked
 is one nobody rechecks.
 
 ```
-[1] What kind of machine is this?
+[1] Which machine is this EFI for?
+      detected: This machine
+       1) This machine <- detected
+       2) Another machine, and I have its hardware report
+       3) Another machine, and I do not have one
+       4) Neither - just write this machine's report, to build for it elsewhere
+      > 1
+
+[2/4] What kind of machine is this?
       detected: Laptop
        1) Desktop
        2) Laptop <- detected
       > 2
 
-[2/3] Which CPU generation?
+[3/4] Which CPU generation?
       detected: Kaby Lake
       ...
       10) Kaby Lake <- detected
       > 10
 
-[3/3] Board or laptop brand?
+[4/4] Board or laptop brand?
       detected: hp
        3) HP <- detected
       > 3
 ```
+
+The first question matters because the USB stick is usually made on a computer
+that already works, not on the one being built for. See
+[Building for another machine](#building-for-another-machine).
 
 It then looks at your network hardware and offers to add the kexts it needs:
 
@@ -92,6 +105,39 @@ double-click it - it carries everything inside, so there is nothing else to get.
 If you would rather not run anything, `EFI-base.zip` and `configs.zip` in the
 same release are the manual route, described under
 [Put the EFI on the USB drive](#put-the-efi-on-the-usb-drive).
+
+<br>
+
+### Building for another machine
+
+Detection reads the computer it runs on. If you are preparing the USB on a
+working PC for a different one, everything it finds - graphics, audio codec,
+network cards, NVMe, trackpad - belongs to the wrong machine, and you do not
+want any of it in the config.
+
+The fix is to take the hardware report on the target machine and carry it over.
+On that machine, from Windows or Linux:
+
+```
+HackintoshEFIBuilder.exe --report machine.json      # or the menu's option 4
+python3 tools/detect.py --report machine.json       # from a clone
+```
+
+That writes one small JSON file: CPU, board, graphics, PCI, USB and audio ids,
+NVMe models. Copy it to the computer you build on and pass it back:
+
+```
+python3 tools/setup.py --machine machine.json
+```
+
+Every question and every piece of advice then applies to that machine. The
+report holds no serial numbers and no raw device dump, so it is safe to send to
+someone who is helping you.
+
+Without a report, answer *Another machine, and I do not have one*. Nothing is
+detected and nothing is guessed at; instead you are asked which Ethernet, Wi-Fi
+and Bluetooth it has, by name, from the drivers this repository ships. Graphics,
+audio and the trackpad need the report - they cannot be worked out from a name.
 
 <br>
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -60,6 +60,8 @@ and identity falls back to a placeholder, each with a warning.
 ## Commands
 
     python3 tools/setup.py                                         # guided, start here
+    python3 tools/setup.py --machine machine.json                  # build for another machine
+    python3 tools/detect.py --report machine.json                  # take that machine's report
     python3 tools/build.py --catalogue                             # published configs
     python3 tools/build.py --name "Laptop/HP/009 - Laptop - Kaby Lake"
     python3 tools/build.py --list                                  # profile axes
@@ -91,6 +93,40 @@ the question as `detected` and marks its row in the list.
 
 It is never preselected. Detection can be wrong, and a wrong answer that arrives
 already ticked is one nobody rechecks, so the person always types a number.
+
+## Which machine the answers are about
+
+Detection reads the machine the tool runs on, and that is usually not the target:
+a USB stick gets made on a computer that already works. So the first question is
+whose hardware this is, before anything is shown as `detected`.
+
+    1) This machine
+    2) Another machine, and I have its hardware report
+    3) Another machine, and I do not have one
+    4) Neither - just write this machine's report, to build for it elsewhere
+
+A report is `detect.probe()` written to JSON, which it survives unchanged because
+it is only strings, numbers and lists. `write_report` drops the raw `pci` dump
+first: nothing downstream reads it, it is large, and it can name a serial number
+in a file meant to be handed to someone else. `read_report` returns a complaint
+rather than raising, because a report that cannot be used is a reason to fall
+back to asking, not a reason to stop - a missing file, a JSON file that is not a
+report, or one written by a newer `REPORT_VERSION` than this copy understands.
+
+With a report, every later section - graphics, audio, framebuffer, trackpad,
+storage, network - works exactly as it does locally, because they all read the
+same dictionary.
+
+Without one, nothing is detected and nothing is guessed. `pick_network()` asks
+which Ethernet, Wi-Fi and Bluetooth that machine has by name, listing the sets in
+`data/network.toml`, and hands `netkexts.entries()` the same match names that
+device matching would have produced. Graphics, audio and the trackpad are not
+offered a by-name equivalent: a card name does not carry the framebuffer id or
+the codec layout, and inventing one is how a config acquires a value nobody can
+trace.
+
+`--no-detect` is the scripting primitive and skips all of it: no detection, no
+scope question and no hardware questions, just the profile menus.
 
 `detect.py` reads the machine through commands that ship with the OS -
 PowerShell CIM on Windows, `lspci` and sysfs on Linux, `system_profiler` and
@@ -471,7 +507,7 @@ workflow rather than repeating it, so what gets published is the build that was
 tested. Either way it has to produce an EFI from its own bundle before the run
 is allowed to pass.
 
-`--answers 2,10,3` replays a menu run non-interactively. That is what CI uses,
+`--answers 1,2,10,3` replays a menu run non-interactively. That is what CI uses,
 on both platforms, instead of piping keystrokes.
 
 Two things the frozen build gets wrong if written the obvious way, both fixed:

--- a/tools/README.md
+++ b/tools/README.md
@@ -128,6 +128,15 @@ trace.
 `--no-detect` is the scripting primitive and skips all of it: no detection, no
 scope question and no hardware questions, just the profile menus.
 
+A test that detects the machine it runs on is a test whose questions change with
+the machine, and `--answers` is positional. A CI runner that happens to have an
+NVMe drive gets asked one more question than one that does not, so the same
+answer string builds a different EFI on the two - and until `--answers` learned
+to say it had run out, it fell through to a closed stdin and failed as an
+unexplained flake instead. `tools/fixtures/no-hardware.json` is a report of
+nothing; passing it and then `--ids`, `--hda-ids` or `--nvme` puts in exactly the
+hardware a test is about and nothing else.
+
 `detect.py` reads the machine through commands that ship with the OS -
 PowerShell CIM on Windows, `lspci` and sysfs on Linux, `system_profiler` and
 `sysctl` on macOS - so it needs no dependencies and no admin rights. Run it on
@@ -507,7 +516,8 @@ workflow rather than repeating it, so what gets published is the build that was
 tested. Either way it has to produce an EFI from its own bundle before the run
 is allowed to pass.
 
-`--answers 1,2,10,3` replays a menu run non-interactively. That is what CI uses,
+`--answers 2,10,3` replays a menu run non-interactively, alongside
+`--machine tools/fixtures/no-hardware.json`. That is what CI uses,
 on both platforms, instead of piping keystrokes.
 
 Two things the frozen build gets wrong if written the obvious way, both fixed:

--- a/tools/detect.py
+++ b/tools/detect.py
@@ -7,10 +7,21 @@ no reason to doubt it.
 
 Windows, Linux and macOS are all read through commands that ship with the OS,
 so this needs no dependencies and no admin rights.
+
+Detection reads the machine it runs on, which is not always the machine being
+built for. `--report` writes everything it found to a file so the build can
+happen somewhere else:
+
+    python3 tools/detect.py --report machine.json     # on the target
+    python3 tools/setup.py --machine machine.json     # anywhere
 """
+import argparse
+import datetime
+import json
 import platform
 import re
 import subprocess
+from pathlib import Path
 
 
 def _run(cmd, shell=False):
@@ -328,7 +339,76 @@ def probe():
     }
 
 
+# --------------------------------------------------------------------------
+# A probe is a plain dictionary of strings, numbers and lists, so it survives a
+# round trip through JSON unchanged. That is what makes building for another
+# machine possible: run this there, carry the file, build here.
+
+REPORT_VERSION = 1
+
+
+def describe(hw):
+    """One line naming the machine a probe came from, for confirming it."""
+    parts = [hw.get('cpu') or 'unknown CPU']
+    if hw.get('cores'):
+        parts.append(f'{hw["cores"]} cores')
+    if hw.get('oem_raw'):
+        parts.append(hw['oem_raw'])
+    if hw.get('laptop') is not None:
+        parts.append('laptop' if hw['laptop'] else 'desktop')
+    return ', '.join(parts)
+
+
+def write_report(path):
+    """Write this machine's probe to a file. Returns what was written."""
+    data = probe()
+    data['report_version'] = REPORT_VERSION
+    data['written'] = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
+    # `pci` is the raw command output the ids were parsed out of. It is large,
+    # it can name a serial number, and nothing downstream reads it, so a file
+    # meant to be sent to someone else does not carry it.
+    data.pop('pci', None)
+    Path(path).write_text(json.dumps(data, indent=2, sort_keys=True), encoding='utf-8')
+    return data
+
+
+def read_report(path):
+    """(probe, complaint) from a file written by write_report.
+
+    A complaint is returned rather than raised: a report that cannot be used is
+    a reason to fall back to asking, not a reason to stop."""
+    p = Path(path)
+    if not p.exists():
+        return None, f'{p} does not exist'
+    try:
+        data = json.loads(p.read_text(encoding='utf-8'))
+    except (OSError, ValueError) as exc:
+        return None, f'{p} could not be read: {exc}'
+    if not isinstance(data, dict) or 'report_version' not in data:
+        return None, (f'{p} is not a hardware report; make one with '
+                      f'"detect.py --report {p.name}" on the machine you are building for')
+    if data['report_version'] > REPORT_VERSION:
+        return None, (f'{p} was written by a newer version of this tool '
+                      f'(report {data["report_version"]}, this one reads {REPORT_VERSION})')
+    data.setdefault('pci', '')
+    return data, None
+
+
 if __name__ == '__main__':
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--report', metavar='FILE',
+                    help='write what was found to a file, to build for this '
+                         'machine from a different one')
+    args = ap.parse_args()
+    if args.report:
+        written = write_report(args.report)
+        print(f'  wrote {args.report}')
+        print(f'  {describe(written)}')
+        print(f'  {len(written["pci_ids"])} PCI, {len(written["usb_ids"])} USB, '
+              f'{len(written["hda_ids"])} audio ids')
+        print(f'\n  Copy it to the machine you build on and run:'
+              f'\n      setup.py --machine {args.report}')
+        raise SystemExit(0)
     for k, v in probe().items():
         if k == 'pci':
             print(f'  {k:10s} {len(v.splitlines())} lines')

--- a/tools/fixtures/README.md
+++ b/tools/fixtures/README.md
@@ -1,0 +1,16 @@
+# Fixtures
+
+`no-hardware.json` is a hardware report describing nothing at all.
+
+It exists because a test that detects the machine it runs on is a test whose
+questions change with the machine. A CI runner that happens to have an NVMe
+drive is asked one more question than one that does not, so a fixed `--answers`
+string builds a different EFI on the two - or runs out and fails on one of them,
+which is exactly what happened and read as a flaky job for a while.
+
+Passing `--machine tools/fixtures/no-hardware.json` starts from nothing, and
+`--ids`, `--usb-ids`, `--hda-ids` and `--nvme` then put in exactly the hardware
+a test is about. Nothing else can appear.
+
+It is not for building an EFI with. A build from it has no advice in it, because
+there is nothing to advise on.

--- a/tools/fixtures/no-hardware.json
+++ b/tools/fixtures/no-hardware.json
@@ -1,0 +1,20 @@
+{
+  "cores": null,
+  "cpu": null,
+  "generation": null,
+  "gpu": [],
+  "gpu_devices": [],
+  "gpu_virtual": [],
+  "hda_ids": [],
+  "laptop": null,
+  "nvme": [],
+  "oem": null,
+  "oem_raw": null,
+  "pci_ids": [],
+  "peripherals": [],
+  "ps2": false,
+  "report_version": 1,
+  "system": "none",
+  "usb_ids": [],
+  "written": "a fixture, not a real machine"
+}

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -6,6 +6,7 @@ the whole file before a single step runs - which is exactly what happened.
 
     python3 tools/selftest.py
 """
+import json
 import os
 import subprocess
 import sys
@@ -91,7 +92,7 @@ def boot_args():
     with tempfile.TemporaryDirectory() as tmp:
         out = Path(tmp) / 'EFI'
         r = run([sys.executable, 'tools/setup.py', '--hda-ids', '10ec:0255',
-                 '--answers', '2,10,3', '--out', str(out)])
+                 '--answers', '1,2,10,3', '--out', str(out)])
         check('the guided build succeeds', r.returncode == 0)
         if r.returncode != 0:
             return
@@ -156,6 +157,50 @@ def framebuffer():
           igpu.report('alder-lake', False, False)[1] == {})
 
 
+def other_machine():
+    """A report has to survive the trip and be refused when it is not one."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / 'machine.json'
+        written = detect.write_report(path)
+        back, complaint = detect.read_report(path)
+        check('a report reads back as it was written', complaint is None, complaint)
+        if back:
+            check('the ids survive the round trip',
+                  back['pci_ids'] == written['pci_ids']
+                  and back['usb_ids'] == written['usb_ids']
+                  and back['hda_ids'] == written['hda_ids'])
+            check('it says which machine and when it was taken',
+                  bool(back.get('written')) and 'system' in back)
+        check('the raw device dump is not carried into a file meant to be sent',
+              'pci' not in json.loads(path.read_text()))
+
+        junk = Path(tmp) / 'junk.json'
+        junk.write_text('{"cpu": "something"}')
+        check('a file that is not a report is refused, not half-read',
+              detect.read_report(junk)[0] is None)
+        check('a missing file is refused', detect.read_report(Path(tmp) / 'no.json')[0] is None)
+
+        ahead = json.loads(path.read_text())
+        ahead['report_version'] = detect.REPORT_VERSION + 1
+        newer = Path(tmp) / 'newer.json'
+        newer.write_text(json.dumps(ahead))
+        check('a report from a newer tool is refused rather than guessed at',
+              detect.read_report(newer)[0] is None)
+
+        # named by hand, because nothing about that machine can be detected
+        out = Path(tmp) / 'EFI'
+        r = run([sys.executable, 'tools/setup.py', '--answers', '3,2,10,3,1,2,1,1',
+                 '--out', str(out)])
+        check('naming the hardware of another machine builds', r.returncode == 0)
+        if r.returncode == 0:
+            have = {p.name for p in (out / 'OC' / 'Kexts').iterdir()}
+            check('what was named is added', 'IntelMausi.kext' in have
+                  and 'IntelBluetoothFirmware.kext' in have, sorted(have))
+            check('what was declined is not', 'AirportItlwm.kext' not in have)
+            check('nothing is claimed about graphics it cannot see',
+                  not (out.parent / 'NEXT-STEPS.txt').exists())
+
+
 def tables_match_sources():
     with tempfile.TemporaryDirectory() as tmp:
         gen = Path(tmp) / 'hardware.toml'
@@ -169,7 +214,8 @@ def tables_match_sources():
 
 if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
-                    trackpad, framebuffer, boot_args, tables_match_sources):
+                    trackpad, framebuffer, boot_args, other_machine,
+                    tables_match_sources):
         print(f'\n{section.__name__}')
         section()
     print()

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -22,14 +22,16 @@ import ocgen
 FAILED = []
 
 
-def run(cmd):
+def run(cmd, may_fail=False):
     """Run a tool and, if it fails, say what it said.
 
     capture_output with check=True raises a CalledProcessError carrying only the
     command line, so a failure here used to reach CI as 'exit status 1' with the
-    reason discarded - which is worse than no test."""
+    reason discarded - which is worse than no test. may_fail is for the checks
+    whose point is that a tool refuses: printing that as a failure would put a
+    page of alarming output in a log where everything went right."""
     r = subprocess.run(cmd, capture_output=True, text=True)
-    if r.returncode != 0:
+    if r.returncode != 0 and not may_fail:
         print(f'\n  --- {" ".join(cmd)} exited {r.returncode} ---')
         for stream in (r.stdout, r.stderr):
             for line in (stream or '').strip().splitlines():
@@ -205,6 +207,37 @@ def other_machine():
                   not (out.parent / 'NEXT-STEPS.txt').exists())
 
 
+def scripted_answers():
+    """One answer string has to work whether the extra question appears or not.
+
+    The line in CI that builds from real detection cannot know what the runner
+    has, so it ends in a decline. That only works if a spare answer is harmless
+    when the question it was for never came - which is what this pins down. It
+    is checked here rather than left to whichever runner happens to be handed
+    out, since a runner with no NVMe drive proves nothing."""
+    fixture = 'tools/fixtures/no-hardware.json'
+    with tempfile.TemporaryDirectory() as tmp:
+        with_drive = Path(tmp) / 'with' / 'EFI'
+        without = Path(tmp) / 'without' / 'EFI'
+        a = run([sys.executable, 'tools/setup.py', '--machine', fixture,
+                 '--nvme', 'Samsung SSD 970 EVO',
+                 '--answers', '2,10,3,3', '--out', str(with_drive)])
+        b = run([sys.executable, 'tools/setup.py', '--machine', fixture,
+                 '--answers', '2,10,3,3', '--out', str(without)])
+        check('the same answers build with the extra question', a.returncode == 0)
+        check('and without it, the spare answer being harmless', b.returncode == 0)
+        if a.returncode == 0:
+            check('declining leaves the kext out',
+                  not (with_drive / 'OC' / 'Kexts' / 'NVMeFix.kext').exists())
+        short = run([sys.executable, 'tools/setup.py', '--machine', fixture,
+                     '--nvme', 'Samsung SSD 970 EVO',
+                     '--answers', '2,10,3', '--out', str(Path(tmp) / 'short' / 'EFI')],
+                    may_fail=True)
+        check('running out of answers says so instead of reading a closed stdin',
+              short.returncode != 0 and 'ran out' in (short.stdout + short.stderr),
+              short.returncode)
+
+
 def tables_match_sources():
     with tempfile.TemporaryDirectory() as tmp:
         gen = Path(tmp) / 'hardware.toml'
@@ -218,7 +251,7 @@ def tables_match_sources():
 
 if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
-                    trackpad, framebuffer, boot_args, other_machine,
+                    trackpad, framebuffer, boot_args, other_machine, scripted_answers,
                     tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -91,8 +91,12 @@ def audio_advice():
 def boot_args():
     with tempfile.TemporaryDirectory() as tmp:
         out = Path(tmp) / 'EFI'
-        r = run([sys.executable, 'tools/setup.py', '--hda-ids', '10ec:0255',
-                 '--answers', '1,2,10,3', '--out', str(out)])
+        # from the fixture, so the questions do not depend on whether the
+        # machine running the test happens to have an NVMe drive
+        r = run([sys.executable, 'tools/setup.py',
+                 '--machine', 'tools/fixtures/no-hardware.json',
+                 '--hda-ids', '10ec:0255',
+                 '--answers', '2,10,3', '--out', str(out)])
         check('the guided build succeeds', r.returncode == 0)
         if r.returncode != 0:
             return

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -9,6 +9,11 @@ nobody rechecks.
 
     python3 tools/setup.py
 
+The first question is which machine the EFI is for, because detection reads the
+machine this runs on and that is often not the target: a USB stick is usually
+made on a computer that already works. Building for another machine either
+reads a report taken from it, or asks by name and claims nothing it cannot know.
+
 Standard library only, no network.
 """
 import argparse
@@ -59,9 +64,34 @@ if os.environ.get('NO_COLOR') or not sys.stdout.isatty():
 
 
 SCRIPTED = []
+SCRIPTING = False
 
 
-def ask(step, total, question, options, detected=None, allow_skip=False):
+def _answer():
+    """The next scripted answer, or a typed one.
+
+    Running out mid-run is a scripting mistake, not a prompt: with --answers the
+    input is usually closed, so falling through to input() would end in an
+    EOFError several frames away from the cause."""
+    if SCRIPTED:
+        raw = SCRIPTED.pop(0)
+        print(f'      > {raw}')
+        return raw
+    if SCRIPTING:
+        sys.exit('--answers ran out: this run asks more questions than it was given')
+    return input('      > ').strip()
+
+
+def prompt(question, note=None):
+    """A free-text answer. Empty means the person declined."""
+    print(f'\n{BOLD}{question}{RESET}')
+    if note:
+        print(f'      {DIM}{note}{RESET}')
+    return _answer().strip()
+
+
+def ask(step, total, question, options, detected=None, allow_skip=False,
+        skip_label='none of these'):
     """One numbered menu. options is [(value, label)]. Returns the chosen value.
 
     `detected` is shown as a note and marks its row, but the person still types
@@ -83,13 +113,9 @@ def ask(step, total, question, options, detected=None, allow_skip=False):
         mark = f' {GREEN}<- detected{RESET}' if value == detected else ''
         print(f'      {i:2d}) {label}{mark}')
     if allow_skip:
-        print(f'      {len(options) + 1:2d}) none of these')
+        print(f'      {len(options) + 1:2d}) {skip_label}')
     while True:
-        if SCRIPTED:
-            raw = SCRIPTED.pop(0)
-            print(f'      > {raw}')
-        else:
-            raw = input('      > ').strip()
+        raw = _answer()
         if raw.isdigit():
             n = int(raw)
             if 1 <= n <= len(options):
@@ -129,11 +155,64 @@ def unbundle():
     return here
 
 
+def show_machine(hw, label):
+    """Print what a probe says, so the person can see it is the right machine."""
+    if not hw.get('cpu'):
+        return
+    print(f'  {DIM}{label}:{RESET} {hw["cpu"]}'
+          + (f', {hw["cores"]} cores' if hw.get('cores') else '')
+          + (f', {hw["oem_raw"]}' if hw.get('oem_raw') else ''))
+    if hw.get('written'):
+        print(f'  {DIM}taken:{RESET}        {hw["written"]} on {hw.get("system", "?")}')
+    for g in hw.get('gpu_devices', [])[:3]:
+        print(f'  {DIM}graphics:{RESET}     {g["name"]}'
+              + (f'  {DIM}[{g["id"]}]{RESET}' if g.get('id') else ''))
+    if hw.get('gpu_virtual'):
+        # named rather than dropped silently: someone who installed one of
+        # these should see that it was recognised and set aside
+        print(f'  {DIM}ignored:{RESET}      {", ".join(hw["gpu_virtual"])}'
+              f'  {DIM}(virtual display adapters, not graphics hardware){RESET}')
+
+
+def pick_network():
+    """Ask by name which network hardware the other machine has.
+
+    Reached only when there is no report to read. Nothing about that machine is
+    known, so the options are the driver sets this repository ships rather than
+    anything matched against device ids, and the answers stay the person's."""
+    picked = set()
+    known = netkexts.sets() + netkexts.variant_sets()
+    for role, label in (('ethernet', 'Ethernet'), ('wifi', 'Wi-Fi'),
+                        ('bluetooth', 'Bluetooth')):
+        options = [(s['match'], s['label']) for s in known if s.get('role') == role]
+        if not options:
+            continue
+        got = ask(0, 0, f'Which {label} does that machine have?', options,
+                  allow_skip=True, skip_label='none, or I do not know')
+        if got:
+            picked.add(got)
+    return picked
+
+
+def load_machine(path):
+    """(probe, label) for a report file, or (None, complaint) if unusable."""
+    hw, complaint = detect.read_report(path)
+    if complaint:
+        return None, complaint
+    return hw, f'report {Path(path).name}'
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--out', default='build/EFI')
     ap.add_argument('--no-detect', action='store_true',
-                    help='skip hardware detection and just ask')
+                    help='skip hardware detection and ask the profile questions only')
+    ap.add_argument('--machine', metavar='FILE',
+                    help='build for the machine in this hardware report instead '
+                         'of the one this runs on')
+    ap.add_argument('--report', metavar='FILE',
+                    help='write this machine\'s hardware report and stop, so an '
+                         'EFI for it can be built elsewhere')
     ap.add_argument('--ids', help='PCI ids to use instead of probing, comma separated')
     ap.add_argument('--usb-ids', help='USB ids to use instead of probing, comma separated')
     ap.add_argument('--hda-ids', help='HD audio codec ids to use instead of probing')
@@ -144,35 +223,25 @@ def main():
     a = ap.parse_args()
 
     if a.answers:
+        global SCRIPTING
+        SCRIPTING = True
         SCRIPTED.extend(x.strip() for x in a.answers.split(',') if x.strip())
 
     started_in = unbundle()
     if started_in:
         a.out = str((started_in / a.out).resolve())
+        for opt in ('machine', 'report', 'usb_map'):
+            if getattr(a, opt):
+                setattr(a, opt, str((started_in / getattr(a, opt)).resolve()))
 
-    hw = {} if a.no_detect else detect.probe()
-    if a.ids is not None or a.usb_ids is not None:
-        hw['pci_ids'] = [x.strip() for x in (a.ids or '').split(',') if x.strip()]
-        hw['usb_ids'] = [x.strip() for x in (a.usb_ids or '').split(',') if x.strip()]
-    if a.hda_ids is not None:
-        hw['hda_ids'] = [x.strip() for x in a.hda_ids.split(',') if x.strip()]
-    if a.nvme is not None:
-        hw['nvme'] = [x.strip() for x in a.nvme.split(',') if x.strip()]
-    print(f'{BOLD}OpenCore EFI builder{RESET}')
-    if hw.get('cpu'):
-        print(f'  {DIM}this machine:{RESET} {hw["cpu"]}'
-              + (f', {hw["cores"]} cores' if hw.get('cores') else '')
-              + (f', {hw["oem_raw"]}' if hw.get('oem_raw') else ''))
-        for g in hw.get('gpu_devices', [])[:3]:
-            print(f'  {DIM}graphics:{RESET}     {g["name"]}'
-                  + (f'  {DIM}[{g["id"]}]{RESET}' if g.get('id') else ''))
-        if hw.get('gpu_virtual'):
-            # named rather than dropped silently: someone who installed one of
-            # these should see that it was recognised and set aside
-            print(f'  {DIM}ignored:{RESET}      {", ".join(hw["gpu_virtual"])}'
-                  f'  {DIM}(virtual display adapters, not graphics hardware){RESET}')
-    elif not a.no_detect:
-        print(f'  {DIM}could not read this machine; every question is still answerable{RESET}')
+    if a.report:
+        written = detect.write_report(a.report)
+        print(f'{BOLD}Hardware report{RESET}')
+        print(f'  wrote {a.report}')
+        print(f'  {detect.describe(written)}')
+        print(f'\n  Copy it to the machine you build on and pass it back:')
+        print(f'      setup.py --machine {Path(a.report).name}')
+        return 0
 
     # a laptop never asks for vendor or core count, so the count is worked out
     # rather than fixed: "[2/3]" should mean two of three questions left
@@ -183,12 +252,84 @@ def main():
         step[0] += 1
         return step[0]
 
+    print(f'{BOLD}OpenCore EFI builder{RESET}')
+
+    # Which machine the EFI is for has to be settled before anything is shown as
+    # detected, because detection reads the machine this runs on. A hint from
+    # the wrong computer is worse than none: it looks like an answer.
+    hw, source, manual = {}, None, False
+    if a.machine:
+        hw, source = load_machine(a.machine)
+        if hw is None:
+            sys.exit(source)
+        show_machine(hw, 'building for')
+    elif a.no_detect:
+        pass
+    else:
+        local = detect.probe()
+        show_machine(local, 'this machine')
+        if not local.get('cpu'):
+            print(f'  {DIM}could not read this machine; every question is still '
+                  f'answerable{RESET}')
+        choice = ask(nxt(), 0, 'Which machine is this EFI for?',
+                     [('this', 'This machine'),
+                      ('file', 'Another machine, and I have its hardware report'),
+                      ('other', 'Another machine, and I do not have one'),
+                      ('report', 'Neither - just write this machine\'s report, '
+                                 'to build for it elsewhere')],
+                     detected='this' if local.get('cpu') else None)
+        if choice == 'report':
+            out = prompt('Where should the report go?',
+                         'a path, or enter for machine.json') or 'machine.json'
+            if started_in:
+                out = str((started_in / out).resolve())
+            written = detect.write_report(out)
+            print(f'\n  wrote {out}')
+            print(f'  {detect.describe(written)}')
+            print(f'\n  Copy it to the machine you build on and pass it back:')
+            print(f'      setup.py --machine {Path(out).name}')
+            return 0
+        if choice == 'this':
+            hw, source = local, 'this machine'
+        elif choice == 'file':
+            while True:
+                path = prompt('Where is the report?',
+                              'a path, or enter to answer the questions instead')
+                if not path:
+                    break
+                if started_in:
+                    path = str((started_in / path).resolve())
+                hw, source = load_machine(path)
+                if hw is not None:
+                    show_machine(hw, 'building for')
+                    break
+                print(f'      {YELLOW}{source}{RESET}')
+                hw = {}
+            manual = not hw
+        else:
+            manual = True
+        if manual:
+            print(f'\n  {DIM}Nothing is known about that machine, so nothing is '
+                  f'detected for it.\n  Graphics, audio and the trackpad need a report '
+                  f'taken there:\n      setup.py --report machine.json{RESET}')
+
+    if a.ids is not None or a.usb_ids is not None:
+        hw['pci_ids'] = [x.strip() for x in (a.ids or '').split(',') if x.strip()]
+        hw['usb_ids'] = [x.strip() for x in (a.usb_ids or '').split(',') if x.strip()]
+    if a.hda_ids is not None:
+        hw['hda_ids'] = [x.strip() for x in a.hda_ids.split(',') if x.strip()]
+    if a.nvme is not None:
+        hw['nvme'] = [x.strip() for x in a.nvme.split(',') if x.strip()]
+    if source is None and (hw.get('pci_ids') or hw.get('hda_ids') or hw.get('nvme')):
+        source = 'the ids you passed'
+
+    asked = step[0]      # the scope question, when it was asked at all
     plat = ask(nxt(), total, 'What kind of machine is this?',
                [('desktop', 'Desktop'), ('laptop', 'Laptop')],
                detected=('laptop' if hw.get('laptop') else
                          'desktop' if hw.get('laptop') is False else None))
 
-    total = 3            # laptop: platform, generation, brand
+    total = asked + 3    # laptop: platform, generation, brand
     vendor = None
     if plat == 'desktop':
         det = ('amd' if hw.get('generation') in ('ryzen-threadripper', 'bulldozer-jaguar')
@@ -197,7 +338,7 @@ def main():
         # first question it cannot honestly claim a total yet
         vendor = ask(nxt(), 0, 'Which CPU vendor?',
                      [('intel', 'Intel'), ('amd', 'AMD')], detected=det)
-        total = 5 if vendor == 'amd' else 4
+        total = asked + (5 if vendor == 'amd' else 4)
     else:
         print(f'\n      {DIM}laptop profiles cover Intel only, so no vendor question{RESET}')
 
@@ -308,6 +449,13 @@ def main():
               f'so nothing is claimed or added{RESET}')
 
     matched = advise.matched_kexts(hw.get('pci_ids', []), hw.get('usb_ids', []))
+    if manual and not matched:
+        # no ids to match, so the person names the hardware instead. Asked only
+        # here: where ids exist, matching them beats being asked to remember.
+        print(f'\n{BOLD}Network{RESET}')
+        print(f'  {DIM}These come from what this repository ships drivers for. Pick what '
+              f'that\n  machine has; anything else is left out rather than guessed at.{RESET}')
+        matched = pick_network()
     # storage has no version ambiguity, so it rides along with the same question
     # rather than adding one - but it must not depend on there being network
     # hardware to match, or a machine with neither gets nothing
@@ -315,9 +463,10 @@ def main():
     # claim the controllers the map is for
     cmd_extra_drop = ['UTBDefault.kext'] if a.usb_map else []
     if matched or storage_kexts or input_kexts:
-        if matched:
+        if matched and not manual:
             print(f'\n{BOLD}Network kexts{RESET}')
-            advise.report(hw['pci_ids'], hw['usb_ids'], 'this machine')
+            advise.report(hw.get('pci_ids', []), hw.get('usb_ids', []),
+                          source or 'the ids you passed')
         mode = ask(0, 0, 'Add these to the EFI?',
                    [('all', 'Yes, for every macOS version they support'),
                     ('one', 'Yes, for one macOS version only'),
@@ -407,9 +556,11 @@ def main():
         os.unlink(notes_file)
     if props_file:
         os.unlink(props_file)
-    elif hw.get('pci_ids') or hw.get('usb_ids'):
+    if not matched and (hw.get('pci_ids') or hw.get('usb_ids')):
+        # nothing matched, so no kext question was asked: say what was seen
         print()
-        advise.report(hw['pci_ids'], hw['usb_ids'], 'this machine')
+        advise.report(hw.get('pci_ids', []), hw.get('usb_ids', []),
+                      source or 'the ids you passed')
 
     print(f'\n  Copy the {BOLD}EFI{RESET} folder from {BOLD}{a.out}{RESET} to the EFI '
           f'partition of your USB drive.')


### PR DESCRIPTION
Detection reads the machine the tool runs on, which is usually not the target: a
USB stick gets made on a computer that already works. Until now the profile
menus were answered by hand while graphics, audio, network kexts, NVMe and the
trackpad came from the wrong machine and went silently into the config.

So the first question is now whose hardware this is:

```
[1] Which machine is this EFI for?
      detected: This machine
       1) This machine <- detected
       2) Another machine, and I have its hardware report
       3) Another machine, and I do not have one
       4) Neither - just write this machine's report, to build for it elsewhere
```

**With a report.** `detect.py --report machine.json`, or option 4, writes
`probe()` to JSON - which it survives unchanged, being only strings, numbers and
lists. Run it on the target, carry the file, `setup.py --machine machine.json`.
Every later section then reads that machine's dictionary, so the advice is as
good as it is locally. The raw `pci` dump is dropped before writing: nothing
reads it, it is large, and it can name a serial number in a file meant to be
sent to someone else. An unreadable, non-report or newer-version file is
refused with a reason rather than half-read.

**Without one.** Nothing is detected and nothing is guessed. The person is asked
which Ethernet, Wi-Fi and Bluetooth that machine has by name, from the sets in
`data/network.toml`, producing the same match names device matching would have.
Graphics, audio and the trackpad get no by-name equivalent: a card name does not
carry a framebuffer id or a codec layout, and inventing one is how a config
acquires a value nobody can trace.

`--no-detect` stays the scripting primitive - no detection, no scope question,
no hardware questions - so every existing `--answers` string that used it is
unchanged. The rest gained a leading `1,`.

Also: `--answers` running out now says so instead of falling through to a closed
stdin, and the trailing hardware report no longer hangs off whether device
properties happened to be written.

Eleven new self-test assertions cover the round trip, the three refusals and the
by-name build. CI builds an EFI all three ways.