### PR TITLE
Do not lose a whole device listing to one undecodable byte

### DIFF
--- a/tools/detect.py
+++ b/tools/detect.py
@@ -25,15 +25,30 @@ from pathlib import Path
 
 
 def _run(cmd, shell=False):
+    """Output of a command, or an empty string. Never raises, never returns None.
+
+    text=True alone decodes with the locale encoding and no error handling, so on
+    a Turkish Windows a device name carrying a byte cp1254 has no character for
+    killed the reader thread inside subprocess. The traceback printed, stdout
+    came back as None, and the whole listing was lost - not just that one name.
+    That is how a laptop with a full complement of PCI devices reported none."""
     try:
-        r = subprocess.run(cmd, shell=shell, capture_output=True, text=True, timeout=25)
-        return r.stdout if r.returncode == 0 else ''
-    except (OSError, subprocess.SubprocessError):
+        r = subprocess.run(cmd, shell=shell, capture_output=True, timeout=25,
+                           text=True, encoding='utf-8', errors='replace')
+        return (r.stdout or '') if r.returncode == 0 else ''
+    except (OSError, subprocess.SubprocessError, ValueError):
         return ''
 
 
+# PowerShell writes in the console code page unless told otherwise, which is not
+# UTF-8 on a non-English Windows. Setting it per call costs nothing and means the
+# bytes match how they are decoded; errors='replace' above covers the rest.
+PS_UTF8 = '[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false; '
+
+
 def _ps(script):
-    return _run(['powershell', '-NoProfile', '-NonInteractive', '-Command', script])
+    return _run(['powershell', '-NoProfile', '-NonInteractive', '-Command',
+                 PS_UTF8 + script])
 
 
 def _read(path):

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -207,6 +207,22 @@ def other_machine():
                   not (out.parent / 'NEXT-STEPS.txt').exists())
 
 
+def undecodable_output():
+    """A byte the encoding cannot name must cost that byte, not the listing.
+
+    On a Turkish Windows the PnP listing carries names in a code page Python was
+    decoding without an error handler, and the reader thread inside subprocess
+    died on the first bad byte: stdout came back empty and a laptop full of PCI
+    devices reported none of them."""
+    out = detect._run([sys.executable, '-c',
+                       "import sys; sys.stdout.buffer.write("
+                       "b'8086:0a16 \\x81\\x8d name\\n')"])
+    check('output survives a byte the encoding has no character for',
+          '8086:0a16' in out and out.endswith('name\n'), repr(out))
+    check('nothing comes back as None, which no caller checks for',
+          isinstance(detect._run(['definitely-not-a-command-here']), str))
+
+
 def scripted_answers():
     """One answer string has to work whether the extra question appears or not.
 
@@ -251,7 +267,7 @@ def tables_match_sources():
 
 if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
-                    trackpad, framebuffer, boot_args, other_machine, scripted_answers,
+                    trackpad, framebuffer, boot_args, other_machine, undecodable_output, scripted_answers,
                     tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -235,6 +235,7 @@ def main():
                 setattr(a, opt, str((started_in / getattr(a, opt)).resolve()))
 
     if a.report:
+        a.report = str(Path(a.report).expanduser().resolve())
         written = detect.write_report(a.report)
         print(f'{BOLD}Hardware report{RESET}')
         print(f'  wrote {a.report}')
@@ -279,10 +280,16 @@ def main():
                                  'to build for it elsewhere')],
                      detected='this' if local.get('cpu') else None)
         if choice == 'report':
-            out = prompt('Where should the report go?',
-                         'a path, or enter for machine.json') or 'machine.json'
-            if started_in:
-                out = str((started_in / out).resolve())
+            # named in full before it is written, not after: "enter for
+            # machine.json" does not say which directory that lands in, and for
+            # the frozen build that is wherever the executable was started
+            # started_in is where the person actually is; when frozen the working
+            # directory has already moved into the unpacked bundle
+            base = started_in or Path.cwd()
+            default = base / 'machine.json'
+            typed = prompt('Where should the report go?',
+                           f'a path, or enter for {default}')
+            out = str((base / Path(typed).expanduser()).resolve()) if typed else str(default)
             written = detect.write_report(out)
             print(f'\n  wrote {out}')
             print(f'  {detect.describe(written)}')


### PR DESCRIPTION
Found on a Turkish Windows laptop. Three tracebacks printed before the first
question, and the hardware report that came out said the machine had no PCI
devices, no USB devices and no peripherals - on a Toshiba with a full set of
them. An EFI built from it had no network kexts and nothing said why.

`subprocess` was called with `text=True` and nothing else, so it decoded with
the locale encoding and no error handler. The first byte cp1254 has no character
for killed the reader thread inside `subprocess`; `stdout` came back as `None`
and the entire listing was lost, not just the name that carried the byte. The
short queries - CPU, manufacturer, graphics, audio codec - survived because
their output happened to be ASCII, which is why the report looked plausible.

* `errors='replace'`, so a byte costs a character rather than a listing.
* Each PowerShell call sets its output encoding to UTF-8 first, so Turkish
  device names arrive as themselves instead of as replacement characters.
* `_run` returns a string in every path. It used to be able to return `None`,
  which no caller checks for.

Two assertions pin it, driven by a command that emits an undecodable byte, so
they do not need a Turkish Windows to run.

Also, from the same session: the report prompt now names the full path it will
write to before you press enter, rather than offering `machine.json` without
saying which directory that is - which for the frozen build is wherever the
executable was started.