### PR TITLE
A keyboard is not a card reader

### DIFF
--- a/tools/detect.py
+++ b/tools/detect.py
@@ -288,24 +288,46 @@ def split_graphics(entries):
     return real, virtual
 
 
-def peripherals(text):
-    """Cameras and card readers, with the bus each is on.
+# The classes the peripherals query asks for, and what each one is. Everything
+# that was not a camera used to fall through to "card reader", so a PS/2
+# keyboard, a remote desktop mouse and an Alps trackpad were all reported as
+# card readers - on screen as well as in the report.
+PNP_CLASS_KIND = {
+    'camera': 'camera', 'image': 'camera',
+    'sdhost': 'card reader', 'mtd': 'card reader',
+    'mouse': 'pointing device', 'keyboard': 'keyboard',
+}
 
-    The bus is the only part worth reporting: a USB camera is handled by the
-    class driver macOS already has, while one that is not on USB is an IPU or
-    MIPI sensor with no macOS driver at all. Which specific reader or sensor
-    works is not something this repository has data for, so it is not claimed."""
+
+def hardware_id(ident):
+    """The enumerator and hardware id of a device path, without the instance.
+
+    `ACPI\\PNP0303\\4&1e2f3a4b&0` becomes `ACPI\\PNP0303`. The tail is the
+    instance path, which says nothing about what the device is and can carry a
+    serial number, so it has no business in a file meant to be sent to someone."""
+    parts = (ident or '').split('\\')
+    return '\\'.join(parts[:2]) if len(parts) > 1 else (ident or '')
+
+
+def peripherals(text):
+    """Cameras, card readers and input devices, with the bus each is on.
+
+    The bus matters for a camera: a USB one is handled by the class driver macOS
+    already has, while one that is not on USB is an IPU or MIPI sensor with no
+    macOS driver at all. Which specific reader or sensor works is not something
+    this repository has data for, so it is not claimed."""
     out = []
     for line in (text or '').splitlines():
         parts = line.split('|')
         if len(parts) < 2:
             continue
-        kind, ident = parts[0].strip(), parts[1]
+        pnp_class, ident = parts[0].strip(), parts[1]
         name = parts[2].strip() if len(parts) > 2 else ident
         if not name:
             continue
-        out.append({'kind': 'camera' if kind.lower() in ('camera', 'image') else 'card reader',
-                    'name': name, 'usb': ident.upper().startswith('USB')})
+        out.append({'kind': PNP_CLASS_KIND.get(pnp_class.lower(), 'other'),
+                    'name': name, 'id': hardware_id(ident),
+                    'usb': ident.upper().startswith('USB')})
     return out
 
 

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -126,11 +126,20 @@ def peripherals():
     found = detect.peripherals(
         'Camera|USB\\VID_04F2&PID_B67C&MI_00\\6&a|Integrated Camera\n'
         'Image|PCI\\VEN_8086&DEV_9D32\\3&b|Intel Imaging Signal Processor\n'
-        'SDHost|PCI\\VEN_10EC&DEV_5229\\4&c|Realtek PCIE CardReader')
+        'SDHost|PCI\\VEN_10EC&DEV_5229\\4&c|Realtek PCIE CardReader\n'
+        'Keyboard|ACPI\\PNP0303\\4&d|Standart PS/2 Klavye\n'
+        'Mouse|ACPI\\ALP0021\\4&e|Alps Pointing-device')
     kinds = [(d['kind'], d['usb']) for d in found]
     check('a usb camera is told apart from an on-board sensor',
           ('camera', True) in kinds and ('camera', False) in kinds, kinds)
     check('a card reader is recognised as one', ('card reader', False) in kinds, kinds)
+    by_name = {d['name']: d for d in found}
+    check('a keyboard is not called a card reader',
+          by_name['Standart PS/2 Klavye']['kind'] == 'keyboard', by_name)
+    check('nor is a trackpad',
+          by_name['Alps Pointing-device']['kind'] == 'pointing device', by_name)
+    check('the hardware id is kept and the instance path is not',
+          by_name['Alps Pointing-device']['id'] == 'ACPI\\ALP0021', by_name)
 
 
 def trackpad():

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -425,10 +425,16 @@ def main():
             notes.append(isteps)
 
     input_lines, input_kexts = inputdev.entries(hw.get('pci_ids'), hw.get('ps2'))
-    if input_lines:
-        print(f'\n{BOLD}Trackpad{RESET}')
-        print('\n'.join(input_lines))
-        notes.append(inputdev.notes(hw.get('pci_ids')))
+    pointing = [d for d in hw.get('peripherals', [])
+                if d['kind'] in ('pointing device', 'keyboard')]
+    if input_lines or pointing:
+        print(f'\n{BOLD}Trackpad and keyboard{RESET}')
+        for dev in pointing:
+            print(f'  {dev["name"]}  {DIM}({dev["kind"]}'
+                  + (f', {dev["id"]}' if dev.get('id') else '') + f'){RESET}')
+        if input_lines:
+            print('\n'.join(input_lines))
+            notes.append(inputdev.notes(hw.get('pci_ids')))
 
     storage_kexts, storage_drives = netkexts.storage_entries(hw.get('nvme'))
     if hw.get('nvme'):
@@ -441,15 +447,19 @@ def main():
         else:
             print(f'      {DIM}Apple NVMe, which is the case NVMeFix is not for{RESET}')
 
-    if hw.get('peripherals'):
+    # the same query answers two questions, so it is split by what each device
+    # is rather than printed under one heading that fits only half of them
+    media = [d for d in hw.get('peripherals', [])
+             if d['kind'] in ('camera', 'card reader')]
+    if media:
         print(f'\n{BOLD}Camera and card reader{RESET}')
-        for dev in hw['peripherals']:
+        for dev in media:
             where = 'on USB' if dev['usb'] else 'not on USB'
             print(f'  {dev["name"]}  {DIM}({dev["kind"]}, {where}){RESET}')
-        if any(d['kind'] == 'camera' and d['usb'] for d in hw['peripherals']):
+        if any(d['kind'] == 'camera' and d['usb'] for d in media):
             print(f'      {DIM}a USB camera is handled by the class driver macOS already '
                   f'has, so it usually needs nothing{RESET}')
-        if any(d['kind'] == 'camera' and not d['usb'] for d in hw['peripherals']):
+        if any(d['kind'] == 'camera' and not d['usb'] for d in media):
             print(f'      {YELLOW}a camera that is not on USB is an IPU or MIPI sensor, '
                   f'which macOS has no driver for{RESET}')
         print(f'      {DIM}beyond that this repository has no support data for these, '


### PR DESCRIPTION
From a real report, once the encoding fix let the peripherals query through.
A Toshiba laptop came back like this:

```
"kind": "card reader", "name": "Standart PS/2 Klavye"
"kind": "card reader", "name": "Uzak Masaüstü Fare Aygıtı"
"kind": "card reader", "name": "Alps Pointing-device"
```

The query asks for `Camera, Image, SDHost, MTD, Mouse, Keyboard`, but the
classifier only knew Camera and Image and let everything else fall through to
"card reader". So a PS/2 keyboard, two remote desktop devices and the trackpad
were all reported as card readers, on screen under a heading that said "Camera
and card reader" and in the report the next build reads.

* Each PNPClass now maps to what it is: camera, card reader, pointing device or
  keyboard, and anything unrecognised is "other" rather than a card reader.
* Input devices print under Trackpad and keyboard, where they belong.
* Each entry carries its hardware id - `ACPI\PNP0303` - with the instance path
  dropped, since that says nothing about what the device is and can carry a
  serial number in a file meant to be sent to someone.

The ids are what the next fix needs. That same report has `"ps2": false` while
listing a PS/2 keyboard and an Alps trackpad, because the rule looks for
`PNP0F13` or `PNP0303` and this machine evidently uses neither. What it does use
is not something to guess at, and until now the report did not say. Now it will.