### PR TITLE
Read PS/2 from the driver, not from the PnP id

### DIFF
--- a/tools/detect.py
+++ b/tools/detect.py
@@ -160,11 +160,15 @@ def _windows():
     out['usb'] = _ps(
         'Get-CimInstance Win32_PnPEntity | Where-Object { $_.PNPDeviceID -like "USB*" } | '
         'ForEach-Object { "$($_.PNPDeviceID)|$($_.Name)" }')
+    # the driver Windows bound is carried along, because it is the only honest
+    # answer to "is this on the PS/2 controller". The PnP id is not: this laptop
+    # calls its PS/2 keyboard ACPI\\TOS7407 and its Alps trackpad ACPI\\TTP1000,
+    # neither of which is the standard PNP0303 or PNP0F13.
     out['peripherals'] = _ps(
         'Get-CimInstance Win32_PnPEntity | Where-Object '
         '{ $_.PNPClass -in @("Camera","Image","SDHost","MTD","Mouse","Keyboard") } '
         '| ForEach-Object '
-        '{ "$($_.PNPClass)|$($_.PNPDeviceID)|$($_.Name)" }')
+        '{ "$($_.PNPClass)|$($_.PNPDeviceID)|$($_.Name)|$($_.Service)" }')
     # BusType 17 is NVMe in the storage WMI classes, which is a cleaner answer
     # than guessing from a PCI class code or a model string.
     out['storage'] = _ps(
@@ -199,6 +203,9 @@ def _linux():
                          __import__('glob').glob('/proc/asound/card*/codec#*'))
     out['peripherals'] = '\n'.join(
         f'Camera|{l}' for l in (out.get('usb') or '').splitlines() if 'cam' in l.lower())
+    # BUS_I8042 is 0x11 in the kernel's input.h, so a device on bus 0011 is on
+    # the PS/2 controller by the kernel's own reckoning
+    out['input'] = _read('/proc/bus/input/devices')
     import glob as _glob
     out['storage'] = '\n'.join(
         f'17|{_read(p + "/model")}' for p in sorted(_glob.glob('/sys/class/nvme/nvme*')))
@@ -309,6 +316,34 @@ def hardware_id(ident):
     return '\\'.join(parts[:2]) if len(parts) > 1 else (ident or '')
 
 
+# Enumerators a device can appear under and still be a device. Remote desktop
+# installs a keyboard and a mouse under TERMINPUT_BUS, the same way a dummy
+# monitor tool installs a display adapter under ROOT: reporting those as the
+# machine's hardware is the kind of wrong answer that looks right.
+REAL_BUSES = ('ACPI', 'USB', 'HID', 'PCI', 'I2C', 'BTHENUM', 'BTHLE')
+
+# Windows binds the 8042 port driver to whatever hangs off the PS/2 controller,
+# whatever the vendor called the device. On Linux the same fact is BUS_I8042,
+# 0x11 in the kernel's input.h, printed as the bus of each input device.
+PS2_DRIVER = 'i8042prt'
+PS2_LINUX_BUS = 'Bus=0011'
+
+
+def ps2_present(raw):
+    """Whether anything is on the PS/2 controller, by the driver actually bound.
+
+    Matching PnP ids was wrong: a Toshiba calls its PS/2 keyboard ACPI\\TOS7407
+    and its Alps trackpad ACPI\\TTP1000, so a machine with both reported neither
+    and got no VoodooPS2 advice."""
+    text = (raw.get('peripherals') or '')
+    if PS2_DRIVER in text.lower():
+        return True
+    if PS2_LINUX_BUS in (raw.get('input') or ''):
+        return True
+    # the standard ids still count, for anything that does use them
+    return 'PNP0F13' in text.upper() or 'PNP0303' in text.upper()
+
+
 def peripherals(text):
     """Cameras, card readers and input devices, with the bus each is on.
 
@@ -323,11 +358,13 @@ def peripherals(text):
             continue
         pnp_class, ident = parts[0].strip(), parts[1]
         name = parts[2].strip() if len(parts) > 2 else ident
+        driver = parts[3].strip() if len(parts) > 3 else ''
         if not name:
             continue
+        bus = ident.split('\\')[0].upper()
         out.append({'kind': PNP_CLASS_KIND.get(pnp_class.lower(), 'other'),
-                    'name': name, 'id': hardware_id(ident),
-                    'usb': ident.upper().startswith('USB')})
+                    'name': name, 'id': hardware_id(ident), 'driver': driver,
+                    'usb': bus == 'USB', 'virtual': bus not in REAL_BUSES})
     return out
 
 
@@ -370,8 +407,7 @@ def probe():
         'hda_ids': sorted(_pairs(raw.get('hda'), HDA_PATTERNS)),
         'nvme': nvme_drives(raw.get('storage')),
         'peripherals': peripherals(raw.get('peripherals')),
-        'ps2': 'PNP0F13' in (raw.get('peripherals') or '').upper()
-               or 'PNP0303' in (raw.get('peripherals') or '').upper(),
+        'ps2': ps2_present(raw),
         'generation': cpu_generation(raw.get('cpu'), bool(laptop)),
     }
 

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -141,6 +141,23 @@ def peripherals():
     check('the hardware id is kept and the instance path is not',
           by_name['Alps Pointing-device']['id'] == 'ACPI\\ALP0021', by_name)
 
+    # a real Toshiba: neither device uses a standard PnP id, so matching ids
+    # reported no PS/2 hardware on a machine whose keyboard and trackpad are both
+    # on the PS/2 controller
+    listing = ('Keyboard|ACPI\\TOS7407\\4&a|Standart PS/2 Klavye|i8042prt\n'
+               'Mouse|ACPI\\TTP1000\\4&b|Alps Pointing-device|i8042prt\n'
+               'Keyboard|TERMINPUT_BUS\\UMB\\1&c|Uzak Masaustu Klavye Aygiti|terminpt')
+    check('PS/2 is read from the driver Windows bound, not from the PnP id',
+          detect.ps2_present({'peripherals': listing}))
+    check('and on Linux from the kernel bus number',
+          detect.ps2_present({'input': 'I: Bus=0011 Vendor=0001 Product=0001'}))
+    check('a machine with neither says so',
+          not detect.ps2_present({'peripherals':
+                                  'Camera|USB\\VID_04F2&PID_B3B2\\6&d|Cam|usbvideo'}))
+    remote = [d for d in detect.peripherals(listing) if d['virtual']]
+    check('remote desktop input is set aside, like a virtual display adapter',
+          [d['name'] for d in remote] == ['Uzak Masaustu Klavye Aygiti'], remote)
+
 
 def trackpad():
     import inputdev

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -427,11 +427,17 @@ def main():
     input_lines, input_kexts = inputdev.entries(hw.get('pci_ids'), hw.get('ps2'))
     pointing = [d for d in hw.get('peripherals', [])
                 if d['kind'] in ('pointing device', 'keyboard')]
+    aside = [d['name'] for d in pointing if d.get('virtual')]
+    pointing = [d for d in pointing if not d.get('virtual')]
     if input_lines or pointing:
         print(f'\n{BOLD}Trackpad and keyboard{RESET}')
         for dev in pointing:
+            on_ps2 = ' on the PS/2 controller' if dev.get('driver') == 'i8042prt' else ''
             print(f'  {dev["name"]}  {DIM}({dev["kind"]}'
-                  + (f', {dev["id"]}' if dev.get('id') else '') + f'){RESET}')
+                  + (f', {dev["id"]}' if dev.get('id') else '') + f'{on_ps2}){RESET}')
+        if aside:
+            print(f'      {DIM}ignored: {", ".join(aside)}  (remote desktop input, '
+                  f'not this machine\'s){RESET}')
         if input_lines:
             print('\n'.join(input_lines))
             notes.append(inputdev.notes(hw.get('pci_ids')))
@@ -449,8 +455,8 @@ def main():
 
     # the same query answers two questions, so it is split by what each device
     # is rather than printed under one heading that fits only half of them
-    media = [d for d in hw.get('peripherals', [])
-             if d['kind'] in ('camera', 'card reader')]
+    real = [d for d in hw.get('peripherals', []) if not d.get('virtual')]
+    media = [d for d in real if d['kind'] in ('camera', 'card reader')]
     if media:
         print(f'\n{BOLD}Camera and card reader{RESET}')
         for dev in media:


### PR DESCRIPTION
The Toshiba report said `"ps2": false` while listing a PS/2 keyboard and an Alps
trackpad. With hardware ids now in the report, the reason is visible:

```
"id": "ACPI\TOS7407",  "name": "Standart PS/2 Klavye"
"id": "ACPI\TTP1000",  "name": "Alps Pointing-device"
```

Neither is `PNP0303` or `PNP0F13`, which is what the rule matched on. A vendor
is free to name its ACPI device whatever it likes, so a list of standard ids
cannot answer this.

What can: on Windows, whatever hangs off the 8042 controller gets the 8042 port
driver bound to it, so the query now carries `$_.Service` and a device driven by
`i8042prt` is on PS/2 by Windows' own reckoning. On Linux the same fact is
BUS_I8042 - `0x11` in the kernel's `input.h` - printed as `Bus=0011` for each
device in `/proc/bus/input/devices`, which is now read. The standard ids still
count for anything that does use them.

Also from the same report: remote desktop installs a keyboard and a mouse under
`TERMINPUT_BUS`, and they were being reported as this machine's input hardware -
the same mistake as reporting a dummy-monitor driver as the graphics card.
Devices are now flagged by whether their enumerator is a real bus, and the
virtual ones are named and set aside rather than listed or dropped silently.

No EFI changes as a result: `VoodooPS2Controller` and its plugins are already in
the laptop base profile, so a PS/2-only laptop was always covered. What was
wrong was what the tool said, and the flag that a future rule would read.