### PR TITLE
Say what the hardware means before asking anything

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -93,6 +93,14 @@ jobs:
           test -d /tmp/by-name/EFI/OC/Kexts/IntelBluetoothFirmware.kext
           test ! -d /tmp/by-name/EFI/OC/Kexts/AirportItlwm.kext
 
+      - name: The hardware summary
+        run: |
+          NONE='--machine tools/fixtures/no-hardware.json'
+          python3 tools/summary.py $NONE
+          python3 tools/setup.py --check $NONE
+          python3 tools/summary.py
+          python3 tools/setup.py --check
+
       - name: Detection and advice run standalone
         run: |
           python3 tools/detect.py

--- a/README.md
+++ b/README.md
@@ -43,6 +43,32 @@ the answer off your machine it says so next to the question, but it never picks
 for you - detection can be wrong, and a wrong answer that arrives already ticked
 is one nobody rechecks.
 
+First it says what your hardware means for macOS:
+
+```
+Hardware for macOS  from this machine
+
+  CPU          Intel(R) Core(TM) i5-4200U CPU @ 1.60GHz  supported     haswell, laptop profile
+  Graphics     Intel(R) HD Graphics Family  [8086:0a16]  supported     Intel iGPU, haswell
+  Audio        Realtek ALC283                            supported     AppleALC, 11 layouts to try
+  Ethernet     Intel Ethernet                            supported     IntelMausi.kext  [8086:1559]
+  Wi-Fi        Intel Wi-Fi                               supported     AirportItlwm.kext  [8086:08b3]
+  Bluetooth    Intel Bluetooth                           supported     IntelBluetoothFirmware.kext
+  Storage      no NVMe                                   -             nothing to add
+  Trackpad     Alps Pointing-device                      supported     on PS/2, which VoodooPS2 covers
+  Camera       TOSHIBA Web Camera - FHD                  supported     USB, so the class driver handles it
+  Card reader  Realtek PCIE CardReader                   unknown       no support data for card readers
+
+  Nothing here is known to be unsupported.
+```
+
+`unknown` means no table here has anything to say about that part, not that it
+will fail. Nothing on this screen stops the build - if a card is unsupported it
+says so and suggests replacing it, and the choice stays yours. `python3
+tools/setup.py --check` prints just this and exits.
+
+Then it asks:
+
 ```
 [1] Which machine is this EFI for?
       detected: This machine

--- a/tools/README.md
+++ b/tools/README.md
@@ -60,6 +60,8 @@ and identity falls back to a placeholder, each with a warning.
 ## Commands
 
     python3 tools/setup.py                                         # guided, start here
+    python3 tools/setup.py --check                                 # what the hardware means, then stop
+    python3 tools/summary.py --machine machine.json                # the same for a report
     python3 tools/setup.py --machine machine.json                  # build for another machine
     python3 tools/detect.py --report machine.json                  # take that machine's report
     python3 tools/build.py --catalogue                             # published configs
@@ -93,6 +95,25 @@ the question as `detected` and marks its row in the list.
 
 It is never preselected. Detection can be wrong, and a wrong answer that arrives
 already ticked is one nobody rechecks, so the person always types a number.
+
+## What the hardware means
+
+`summary.py` is the screen printed before the first question: one line per part,
+with `supported`, `not supported`, `unknown` or `-`.
+
+Every verdict is composed from a table that already backs a decision elsewhere -
+`data/gpu.toml` for the cards, AppleALC's layouts for the codec, the device ids
+`hwtable.py` reads out of the kexts for the network parts, the profile tree for
+the CPU - so the screen cannot claim something the build then contradicts. Where
+a table has nothing to say the row is `unknown` and the detail says why. A card
+reader gets `unknown` and will keep getting it until there is data to base an
+answer on; a verdict invented for it would be worse than the blank.
+
+Nothing on that screen stops a build. It runs before the questions so that an
+unsupported Wi-Fi card is known before four answers, not after.
+
+Rows that would be noise are left out rather than filled in: a desktop with no
+pointing device gets no trackpad row.
 
 ## Which machine the answers are about
 

--- a/tools/pyinstaller.spec
+++ b/tools/pyinstaller.spec
@@ -19,7 +19,8 @@ a = Analysis(
     [os.path.join(TOOLS, 'setup.py')],
     pathex=[TOOLS],
     datas=datas,
-    hiddenimports=['advise', 'build', 'detect', 'itlwm', 'netkexts', 'ocgen'],
+    hiddenimports=['advise', 'audio', 'build', 'detect', 'gpu', 'igpu',
+                   'inputdev', 'itlwm', 'netkexts', 'ocgen', 'summary'],
     excludes=['tkinter', 'unittest', 'pydoc_data', 'test'],
 )
 pyz = PYZ(a.pure)

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -280,6 +280,56 @@ def scripted_answers():
               short.returncode)
 
 
+def hardware_summary():
+    """The screen shown before any question, composed from the same tables."""
+    import summary
+    toshiba = {
+        'cpu': 'Intel(R) Core(TM) i5-4200U CPU @ 1.60GHz', 'generation': 'haswell',
+        'laptop': True, 'ps2': True, 'nvme': [], 'hda_ids': ['10ec:0283'],
+        'gpu_devices': [{'id': '8086:0a16', 'name': 'Intel(R) HD Graphics Family'}],
+        'pci_ids': ['8086:1559', '8086:08b3'], 'usb_ids': ['8087:07dc'],
+        'peripherals': [
+            {'kind': 'pointing device', 'name': 'Alps Pointing-device',
+             'usb': False, 'virtual': False, 'driver': 'i8042prt'},
+            {'kind': 'card reader', 'name': 'Realtek PCIE CardReader',
+             'usb': False, 'virtual': False, 'driver': 'rtsper'},
+            {'kind': 'keyboard', 'name': 'Uzak Masaustu Klavye',
+             'usb': False, 'virtual': True, 'driver': 'terminpt'}]}
+    by_part = {}
+    for r in summary.rows(toshiba):
+        by_part.setdefault(r['part'], []).append(r)
+    check('a machine that works says so on every row it has data for',
+          not [r for rs in by_part.values() for r in rs
+               if r['verdict'] == summary.UNSUPPORTED], by_part)
+    check('the network rows name the kext, not just a yes',
+          'IntelMausi.kext' in by_part['Ethernet'][0]['detail'], by_part.get('Ethernet'))
+    check('a PS/2 trackpad is covered by the profile, and says which',
+          by_part['Trackpad'][0]['verdict'] == summary.SUPPORTED, by_part.get('Trackpad'))
+    check('a card reader stays unknown rather than being guessed at',
+          by_part['Card reader'][0]['verdict'] == summary.UNKNOWN)
+
+    desktop = dict(toshiba, laptop=False, ps2=False, peripherals=[],
+                   cpu='Intel(R) Core(TM) i9-14900K', generation='raptor-lake',
+                   hda_ids=['ffff:ffff'],
+                   gpu_devices=[{'id': '8086:e20b', 'name': 'Intel Arc B580'},
+                                {'id': '8086:a780', 'name': 'Intel UHD Graphics 770'}])
+    parts = [r['part'] for r in summary.rows(desktop)]
+    verdicts = {(r['part'], r['what']): r['verdict'] for r in summary.rows(desktop)}
+    check('an unsupported card and an unsupported igpu are both called out',
+          [v for (p_, _), v in verdicts.items()
+           if p_ == 'Graphics'] == [summary.UNSUPPORTED] * 2, verdicts)
+    check('a codec AppleALC does not carry is not called supported',
+          verdicts[('Audio', 'ffff:ffff')] == summary.UNSUPPORTED, verdicts)
+    check('a desktop with no pointing device gets no trackpad row',
+          'Trackpad' not in parts, parts)
+
+    blank, complaint = detect.read_report('tools/fixtures/no-hardware.json')
+    check('a machine nothing is known about renders without claiming anything',
+          complaint is None and not [r for r in summary.rows(blank)
+                                     if r['verdict'] == summary.SUPPORTED])
+    check('and it still renders', len(summary.render(blank, 'nothing')) > 3)
+
+
 def tables_match_sources():
     with tempfile.TemporaryDirectory() as tmp:
         gen = Path(tmp) / 'hardware.toml'
@@ -294,6 +344,7 @@ def tables_match_sources():
 if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
                     trackpad, framebuffer, boot_args, other_machine, undecodable_output, scripted_answers,
+                    hardware_summary,
                     tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -31,6 +31,7 @@ import igpu
 import inputdev
 import netkexts
 import ocgen
+import summary
 
 PROFILES = Path('profiles')
 
@@ -213,6 +214,8 @@ def main():
     ap.add_argument('--report', metavar='FILE',
                     help='write this machine\'s hardware report and stop, so an '
                          'EFI for it can be built elsewhere')
+    ap.add_argument('--check', action='store_true',
+                    help='print what the hardware means for macOS and stop')
     ap.add_argument('--ids', help='PCI ids to use instead of probing, comma separated')
     ap.add_argument('--usb-ids', help='USB ids to use instead of probing, comma separated')
     ap.add_argument('--hda-ids', help='HD audio codec ids to use instead of probing')
@@ -254,6 +257,18 @@ def main():
         return step[0]
 
     print(f'{BOLD}OpenCore EFI builder{RESET}')
+
+    if a.check:
+        if a.machine:
+            checked, complaint = load_machine(a.machine)
+            if checked is None:
+                sys.exit(complaint)
+            where = f'report {Path(a.machine).name}'
+        else:
+            checked, where = detect.probe(), 'this machine'
+        print()
+        print('\n'.join(summary.render(checked, where)))
+        return 0
 
     # Which machine the EFI is for has to be settled before anything is shown as
     # detected, because detection reads the machine this runs on. A hint from
@@ -329,6 +344,12 @@ def main():
         hw['nvme'] = [x.strip() for x in a.nvme.split(',') if x.strip()]
     if source is None and (hw.get('pci_ids') or hw.get('hda_ids') or hw.get('nvme')):
         source = 'the ids you passed'
+
+    if hw.get('cpu') or hw.get('pci_ids'):
+        # before any question, so nobody answers four of them to be told at the
+        # end that the Wi-Fi card has to be replaced
+        print()
+        print('\n'.join(summary.render(hw, source or 'this machine')))
 
     asked = step[0]      # the scope question, when it was asked at all
     plat = ask(nxt(), total, 'What kind of machine is this?',

--- a/tools/summary.py
+++ b/tools/summary.py
@@ -1,0 +1,234 @@
+"""What a machine's hardware means for macOS, one line each, before anything else.
+
+Every verdict here is composed from a table that already backs a decision
+elsewhere in these tools - the AMD card list, AppleALC's layouts, the device ids
+read out of the kexts - so this screen cannot say something the build would
+then contradict. Where a table has nothing to say, the row says `unknown` and
+names why. That is the whole point: a blank is a fact, and inventing a verdict
+for a card reader nobody has data for would be worse than admitting to it.
+
+Nothing here stops a build. It is a report, and the decision stays with whoever
+is reading it.
+
+    python3 tools/summary.py                       # this machine
+    python3 tools/summary.py --machine report.json
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import advise
+import audio
+import detect
+import gpu
+import inputdev
+
+PROFILES = Path('profiles')
+
+SUPPORTED, UNSUPPORTED, UNKNOWN, ABSENT = 'supported', 'not supported', 'unknown', '-'
+
+BOLD, DIM, GREEN, YELLOW, RED, RESET = (
+    '\033[1m', '\033[2m', '\033[32m', '\033[33m', '\033[31m', '\033[0m')
+if os.environ.get('NO_COLOR') or not sys.stdout.isatty():
+    BOLD = DIM = GREEN = YELLOW = RED = RESET = ''
+
+COLOUR = {SUPPORTED: GREEN, UNSUPPORTED: RED, UNKNOWN: YELLOW, ABSENT: DIM}
+
+AMD_GENERATIONS = ('ryzen-threadripper', 'bulldozer-jaguar')
+
+
+def row(part, what, verdict, detail=''):
+    return {'part': part, 'what': what, 'verdict': verdict, 'detail': detail}
+
+
+def platform_name(hw):
+    gen = hw.get('generation')
+    if hw.get('laptop'):
+        return 'laptop'
+    return 'desktop-amd' if gen in AMD_GENERATIONS else 'desktop-intel'
+
+
+def cpu_row(hw):
+    gen, name = hw.get('generation'), hw.get('cpu')
+    if not name:
+        return row('CPU', 'not readable', UNKNOWN, 'answer the question by hand')
+    if not gen:
+        # the decoder returns nothing rather than a guess for Xeon, Pentium,
+        # first generation Core and anything newer than it knows
+        return row('CPU', name, UNKNOWN,
+                   'this generation is not one the decoder recognises')
+    pname = platform_name(hw)
+    profile = PROFILES / 'cpu' / pname / f'{gen}.toml'
+    if profile.exists():
+        return row('CPU', name, SUPPORTED, f'{gen}, {pname} profile')
+    return row('CPU', name, UNSUPPORTED, f'no {pname} profile for {gen}')
+
+
+def graphics_rows(hw):
+    out = []
+    for device in hw.get('gpu_devices', []):
+        verdict, entry = gpu.classify(device, hw.get('generation'))
+        detail = ''
+        if entry:
+            detail = entry.get('family') or entry.get('name') or ''
+            if entry.get('note'):
+                detail = f'{detail}, {entry["note"]}' if detail else entry['note']
+        state = {'works': SUPPORTED, 'works-spoofed': SUPPORTED,
+                 'unsupported': UNSUPPORTED}.get(verdict, UNKNOWN)
+        if verdict == 'works-spoofed':
+            detail = (detail + ', with a spoof') if detail else 'with a spoof'
+        if state is UNKNOWN and not detail:
+            detail = 'not in the card table or the iGPU list'
+        name = device.get('name') or 'graphics'
+        if device.get('id'):
+            name = f'{name}  [{device["id"]}]'
+        out.append(row('Graphics', name, state, detail))
+    if not out:
+        out.append(row('Graphics', 'none readable', UNKNOWN,
+                       'nothing was reported on the graphics bus'))
+    return out
+
+
+def audio_row(hw):
+    ids = hw.get('hda_ids') or []
+    if not ids:
+        return row('Audio', 'no codec readable', UNKNOWN, '')
+    found = audio.find(ids)
+    if not found:
+        return row('Audio', ', '.join(ids), UNSUPPORTED,
+                   'no AppleALC layout names this codec')
+    codec = found[0]
+    layouts = len(codec['layout'])
+    return row('Audio', f"{codec['vendor']} {codec['codec']}", SUPPORTED,
+               f'AppleALC, {layouts} layout' + ('s to try' if layouts != 1 else ''))
+
+
+def network_rows(hw):
+    index = advise.load_table()
+    seen = {}
+    for bus, ids in (('pci', hw.get('pci_ids') or []), ('usb', hw.get('usb_ids') or [])):
+        for i in ids:
+            for d in index.get((bus, i), []):
+                seen.setdefault(d['role'], (i, d))
+    out = []
+    for role, label in (('ethernet', 'Ethernet'), ('wifi', 'Wi-Fi'),
+                        ('bluetooth', 'Bluetooth')):
+        hit = seen.get(role)
+        if hit:
+            device_id, d = hit
+            out.append(row(label, d['label'], SUPPORTED,
+                           f'{d["kext"]}  [{device_id}]'))
+        elif hw.get('pci_ids') or hw.get('usb_ids'):
+            # the devices were read and none of them matched, which is a fact
+            # worth stating: either macOS needs no kext, or the card has to go
+            out.append(row(label, 'nothing recognised', UNKNOWN,
+                           'no kext here claims a device on this machine'))
+        else:
+            out.append(row(label, 'no devices readable', UNKNOWN, ''))
+    return out
+
+
+def storage_row(hw):
+    drives = hw.get('nvme') or []
+    if not drives:
+        return row('Storage', 'no NVMe', ABSENT, 'nothing to add')
+    third = [d for d in drives if 'apple' not in d.lower()]
+    if third:
+        return row('Storage', ', '.join(third), SUPPORTED, 'NVMeFix')
+    return row('Storage', ', '.join(drives), SUPPORTED,
+               'Apple NVMe, which is the case NVMeFix is not for')
+
+
+def input_row(hw):
+    """The trackpad row, or nothing on a machine that has no trackpad to speak of."""
+    i2c = inputdev.controllers(hw.get('pci_ids') or [])
+    pointing = [d for d in hw.get('peripherals', [])
+                if d.get('kind') == 'pointing device' and not d.get('virtual')]
+    if not (hw.get('laptop') or i2c or pointing):
+        return None
+    name = pointing[0]['name'] if pointing else ('I2C trackpad' if i2c else 'not readable')
+    if i2c:
+        return row('Trackpad', name, SUPPORTED, f'VoodooI2C  [{", ".join(i2c)}]')
+    if hw.get('ps2'):
+        return row('Trackpad', name, SUPPORTED,
+                   'on PS/2, which VoodooPS2 in the laptop profile covers')
+    return row('Trackpad', name, UNKNOWN, 'no I2C controller and nothing on PS/2')
+
+
+def peripheral_rows(hw):
+    out = []
+    real = [d for d in hw.get('peripherals', []) if not d.get('virtual')]
+    for dev in [d for d in real if d['kind'] == 'camera']:
+        if dev['usb']:
+            out.append(row('Camera', dev['name'], SUPPORTED,
+                           'USB, so the class driver macOS has handles it'))
+        else:
+            out.append(row('Camera', dev['name'], UNSUPPORTED,
+                           'not on USB, so an IPU or MIPI sensor'))
+    for dev in [d for d in real if d['kind'] == 'card reader']:
+        out.append(row('Card reader', dev['name'], UNKNOWN,
+                       'this repository has no support data for card readers'))
+    return out
+
+
+def rows(hw):
+    """Every row, in the order they are worth reading."""
+    out = [cpu_row(hw)] + graphics_rows(hw) + [audio_row(hw)]
+    out += network_rows(hw) + [storage_row(hw), input_row(hw)]
+    return [r for r in out + peripheral_rows(hw) if r]
+
+
+def _fit(text, width):
+    return text if len(text) <= width else text[:width - 1] + '\u2026'
+
+
+def render(hw, source='this machine'):
+    """The whole screen as lines."""
+    table = rows(hw)
+    width = max(len(r['what']) for r in table)
+    width = min(max(width, 24), 44)
+    lines = [f'{BOLD}Hardware for macOS{RESET}  {DIM}from {source}{RESET}', '']
+    for r in table:
+        what = _fit(r['what'], width)
+        # the long form of a verdict belongs in the section that acts on it; here
+        # a line that wraps costs more than the words at the end are worth
+        detail = _fit(r['detail'], 46)
+        colour = COLOUR[r['verdict']]
+        lines.append(f'  {r["part"]:<12s} {what:<{width}s}  '
+                     f'{colour}{r["verdict"]:<14s}{RESET}{DIM}{detail}{RESET}'.rstrip())
+    bad = [r for r in table if r['verdict'] == UNSUPPORTED]
+    unknown = [r for r in table if r['verdict'] == UNKNOWN]
+    lines.append('')
+    if bad:
+        parts = list(dict.fromkeys(r['part'] for r in bad))   # Graphics once, not twice
+        lines.append(f'  {RED}macOS does not support {len(bad)} of these: '
+                     f'{", ".join(parts)}.{RESET}')
+        lines.append(f'  {DIM}Replacing the part is usually the answer. This does not '
+                     f'stop the build, and the sections below say more.{RESET}')
+    else:
+        lines.append(f'  {GREEN}Nothing here is known to be unsupported.{RESET}')
+    if unknown:
+        lines.append(f'  {DIM}{len(unknown)} left as unknown, where no table here has '
+                     f'anything to say.{RESET}')
+    return lines
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--machine', metavar='FILE', help='read a hardware report instead')
+    a = ap.parse_args(argv)
+    if a.machine:
+        hw, complaint = detect.read_report(a.machine)
+        if complaint:
+            sys.exit(complaint)
+        source = f'report {Path(a.machine).name}'
+    else:
+        hw, source = detect.probe(), 'this machine'
+    print('\n'.join(render(hw, source)))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
One line per part, before the first question, so an unsupported Wi-Fi card is
known before four answers rather than after.

```
Hardware for macOS  from report machine.json

  CPU          Intel(R) Core(TM) i5-4200U CPU @ 1.60GHz  supported     haswell, laptop profile
  Graphics     Intel(R) HD Graphics Family  [8086:0a16]  supported     Intel iGPU, haswell
  Audio        Realtek ALC283                            supported     AppleALC, 11 layouts to try
  Ethernet     Intel Ethernet                            supported     IntelMausi.kext  [8086:1559]
  Wi-Fi        Intel Wi-Fi                               supported     AirportItlwm.kext  [8086:08b3]
  Bluetooth    Intel Bluetooth                           supported     IntelBluetoothFirmware.kext
  Storage      no NVMe                                   -             nothing to add
  Trackpad     Alps Pointing-device                      supported     on PS/2, which VoodooPS2 covers
  Camera       TOSHIBA Web Camera - FHD                  supported     USB, so the class driver handles it
  Card reader  Realtek PCIE CardReader                   unknown       no support data for card readers

  Nothing here is known to be unsupported.
  1 left as unknown, where no table here has anything to say.
```

`summary.py` composes existing tables rather than adding one: `data/gpu.toml`
for the cards, AppleALC's layouts for the codec, the device ids `hwtable.py`
reads out of the kexts for the network parts, the profile tree for the CPU. So
the screen cannot claim something the build then contradicts, and a table that
gains a card gains it here too.

Four verdicts, and `unknown` is a real one. A card reader gets `unknown` and
will keep getting it until there is data to base an answer on - inventing a
verdict there would be worse than the blank. Rows that would be noise are left
out rather than filled in: a desktop with no pointing device gets no trackpad
row.

Nothing on the screen stops a build. An unsupported card is named, replacing it
is suggested, and the choice stays with whoever is reading.

`--check` prints it and exits, which pairs with `--report` on a machine you are
not building on.

Nine assertions cover a machine that works, one with an unsupported card and an
unsupported iGPU, a codec AppleALC does not carry, the desktop row that should
not appear, and the no-hardware fixture claiming nothing.