### PR TITLE
Show the summary before the first question, not after

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -113,7 +113,16 @@ Nothing on that screen stops a build. It runs before the questions so that an
 unsupported Wi-Fi card is known before four answers, not after.
 
 Rows that would be noise are left out rather than filled in: a desktop with no
-pointing device gets no trackpad row.
+pointing device gets no trackpad row, and a machine where every row would say
+`unknown` gets one line saying so instead of a table saying nothing. That last
+case is what a Mac produces - it reports its own hardware, which none of these
+tables cover.
+
+The screen goes above the first question, including the one asking which machine
+this is for, so that nothing is answered before it is seen. Answering that
+question with a report shows the summary again, for that machine. Ids passed on
+the command line are folded in before it renders, so it describes what will
+actually be built rather than what was detected.
 
 ## Which machine the answers are about
 

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -328,6 +328,9 @@ def hardware_summary():
           complaint is None and not [r for r in summary.rows(blank)
                                      if r['verdict'] == summary.SUPPORTED])
     check('and it still renders', len(summary.render(blank, 'nothing')) > 3)
+    check('a table of nothing but unknown is not worth printing',
+          not summary.worth_showing(blank))
+    check('one that says something is', summary.worth_showing(toshiba))
 
 
 def tables_match_sources():

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -195,6 +195,32 @@ def pick_network():
     return picked
 
 
+def overrides(a, hw):
+    """Fold the ids a caller passed into a probe, in place.
+
+    Applied as soon as the machine is settled rather than just before the build,
+    so the summary describes what will actually be built for."""
+    if a.ids is not None or a.usb_ids is not None:
+        hw['pci_ids'] = [x.strip() for x in (a.ids or '').split(',') if x.strip()]
+        hw['usb_ids'] = [x.strip() for x in (a.usb_ids or '').split(',') if x.strip()]
+    if a.hda_ids is not None:
+        hw['hda_ids'] = [x.strip() for x in a.hda_ids.split(',') if x.strip()]
+    if a.nvme is not None:
+        hw['nvme'] = [x.strip() for x in a.nvme.split(',') if x.strip()]
+    return hw
+
+
+def describe_machine(hw, label, source):
+    """The banner and the summary for one machine."""
+    show_machine(hw, label)
+    if summary.worth_showing(hw):
+        print()
+        print('\n'.join(summary.render(hw, source)))
+    elif hw:
+        print(f'  {DIM}nothing here is in any table this repository has, so there is '
+              f'no summary to give{RESET}')
+
+
 def load_machine(path):
     """(probe, label) for a report file, or (None, complaint) if unusable."""
     hw, complaint = detect.read_report(path)
@@ -278,12 +304,14 @@ def main():
         hw, source = load_machine(a.machine)
         if hw is None:
             sys.exit(source)
-        show_machine(hw, 'building for')
+        describe_machine(overrides(a, hw), 'building for', source)
     elif a.no_detect:
         pass
     else:
-        local = detect.probe()
-        show_machine(local, 'this machine')
+        local = overrides(a, detect.probe())
+        # the summary goes above the first question, not after it: the point of
+        # showing it is that nobody answers anything before seeing it
+        describe_machine(local, 'this machine', 'this machine')
         if not local.get('cpu'):
             print(f'  {DIM}could not read this machine; every question is still '
                   f'answerable{RESET}')
@@ -323,7 +351,7 @@ def main():
                     path = str((started_in / path).resolve())
                 hw, source = load_machine(path)
                 if hw is not None:
-                    show_machine(hw, 'building for')
+                    describe_machine(overrides(a, hw), 'building for', source)
                     break
                 print(f'      {YELLOW}{source}{RESET}')
                 hw = {}
@@ -335,21 +363,10 @@ def main():
                   f'detected for it.\n  Graphics, audio and the trackpad need a report '
                   f'taken there:\n      setup.py --report machine.json{RESET}')
 
-    if a.ids is not None or a.usb_ids is not None:
-        hw['pci_ids'] = [x.strip() for x in (a.ids or '').split(',') if x.strip()]
-        hw['usb_ids'] = [x.strip() for x in (a.usb_ids or '').split(',') if x.strip()]
-    if a.hda_ids is not None:
-        hw['hda_ids'] = [x.strip() for x in a.hda_ids.split(',') if x.strip()]
-    if a.nvme is not None:
-        hw['nvme'] = [x.strip() for x in a.nvme.split(',') if x.strip()]
+    if a.no_detect:
+        overrides(a, hw)
     if source is None and (hw.get('pci_ids') or hw.get('hda_ids') or hw.get('nvme')):
         source = 'the ids you passed'
-
-    if hw.get('cpu') or hw.get('pci_ids'):
-        # before any question, so nobody answers four of them to be told at the
-        # end that the Wi-Fi card has to be replaced
-        print()
-        print('\n'.join(summary.render(hw, source or 'this machine')))
 
     asked = step[0]      # the scope question, when it was asked at all
     plat = ask(nxt(), total, 'What kind of machine is this?',

--- a/tools/summary.py
+++ b/tools/summary.py
@@ -180,6 +180,15 @@ def rows(hw):
     return [r for r in out + peripheral_rows(hw) if r]
 
 
+def worth_showing(hw):
+    """Whether a summary of this machine would say anything.
+
+    A table of nothing but `unknown` is not a report, it is noise - and it is
+    what a Mac produces, since it reports its own hardware and this reads none
+    of it. One line saying so beats ten saying nothing."""
+    return any(r['verdict'] in (SUPPORTED, UNSUPPORTED) for r in rows(hw))
+
+
 def _fit(text, width):
     return text if len(text) <= width else text[:width - 1] + '\u2026'
 


### PR DESCRIPTION
The summary landed after the scope question, so the first screen was still just
the three banner lines and you had to answer something to see it. The point of
the screen is that nothing gets answered before it is read, so it moves above
every question.

Answering the scope question with a report shows the summary again, for that
machine - which is the one that matters.

Two things that fall out of the move:

* Ids passed on the command line (`--ids`, `--hda-ids`, `--nvme`) are folded in
  before the summary renders rather than just before the build, so the screen
  describes what will actually be built.
* A machine where every row would say `unknown` now gets one line saying so
  instead of a table saying nothing ten times. That is what a Mac produces: it
  reports its own hardware, which none of these tables cover, and a wall of
  `unknown` about the wrong computer is worse than an admission.