### PR TITLE
Name the card, not the driver set

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -118,6 +118,13 @@ pointing device gets no trackpad row, and a machine where every row would say
 case is what a Mac produces - it reports its own hardware, which none of these
 tables cover.
 
+Network rows name the card the way the machine named it, not the way the driver
+set is labelled: `Intel(R) Dual Band Wireless-AC 3160`, not `Intel Wi-Fi`. The
+model is printed beside the id by every source - after the pipe on Windows,
+before the bracketed id in `lspci -nn`, after it in `lsusb` - and `detect._names`
+keeps it. There is one row per matched device rather than per role, so a machine
+with two NICs shows both.
+
 The screen goes above the first question, including the one asking which machine
 this is for, so that nothing is answered before it is seen. Answering that
 question with a report shows the summary again, for that machine. Ids passed on

--- a/tools/advise.py
+++ b/tools/advise.py
@@ -55,9 +55,10 @@ def matched_kexts(pci, usb):
     return out
 
 
-def report(pci, usb, source):
+def report(pci, usb, source, names=None):
     """Print what the given devices need. Shared with setup.py."""
     index = load_table()
+    names = names or {}
     hits = collections.defaultdict(list)
     for bus, ids in (('pci', pci), ('usb', usb)):
         for i in ids:
@@ -87,8 +88,9 @@ def report(pci, usb, source):
             if key in seen:
                 continue
             seen.add(key)
+            model = names.get(device_id)
             print(f'      {GREEN}{device_id}{RESET}  needs {BOLD}{d["kext"]}{RESET}'
-                  f'  {DIM}{d["label"]}, v{d["version"]}{RESET}')
+                  f'  {DIM}{model or d["label"]}, v{d["version"]}{RESET}')
 
     if [r for r in hits if len({d['kext'] for _, d in hits[r]}) > 1]:
         print(f'\n  {DIM}Some devices match more than one kext, because they target different\n'

--- a/tools/detect.py
+++ b/tools/detect.py
@@ -260,6 +260,41 @@ def _pairs(text, patterns):
     return out
 
 
+def _names(text, patterns):
+    r"""{id: name} for the lines an id was found on.
+
+    The machine already prints the model beside the id and it was being thrown
+    away, so a Wi-Fi card the tool had fully identified was reported as the name
+    of the driver set it belongs to - "Intel Wi-Fi" rather than what it is.
+
+    Each source puts the name somewhere different, and the id itself says which:
+
+        Windows   PCI\VEN_8086&DEV_1559&...|Intel(R) Ethernet Connection I218-V
+        lspci     00:19.0 Ethernet controller: Intel Corporation I218-V [8086:1559] (rev 04)
+        lsusb     Bus 001 Device 004: ID 8087:07dc Intel Corp. Bluetooth
+    """
+    out = {}
+    for line in (text or '').splitlines():
+        for pat in patterns:
+            m = pat.search(line)
+            if not m:
+                continue
+            key = f'{m.group(1).lower()}:{m.group(2).lower()}'
+            if '|' in line:
+                name = line.rsplit('|', 1)[1]                # Windows
+            elif line[m.start():m.start() + 1] == '[':
+                # lspci, where the id is bracketed and the model comes before it,
+                # after the device class. Anything after is "(rev 04)".
+                name = line[:m.start()].split(': ', 1)[-1]
+            else:
+                name = line[m.end():]                        # lsusb
+            name = name.strip().strip('()').strip()
+            if name and key not in out:
+                out[key] = name
+            break
+    return out
+
+
 def _apple_pairs(text, vendor_key, device_key):
     """system_profiler prints the two halves on separate lines within a block."""
     out, vendor = set(), None
@@ -405,6 +440,10 @@ def probe():
                           | (_apple_pairs(raw.get('usb'), 'Vendor ID', 'Product ID')
                              if system == 'Darwin' else set())),
         'hda_ids': sorted(_pairs(raw.get('hda'), HDA_PATTERNS)),
+        # the model beside each id, where the machine printed one. A model name
+        # is not a serial number, so it travels in a report like the id does.
+        'device_names': {**_names(raw.get('pci'), PCI_PATTERNS),
+                         **_names(raw.get('usb'), USB_PATTERNS)},
         'nvme': nvme_drives(raw.get('storage')),
         'peripherals': peripherals(raw.get('peripherals')),
         'ps2': ps2_present(raw),

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -332,6 +332,49 @@ def hardware_summary():
           not summary.worth_showing(blank))
     check('one that says something is', summary.worth_showing(toshiba))
 
+    # the model the machine printed, rather than the name of the driver set
+    named = dict(toshiba, pci_ids=['8086:1559', '10ec:8168', '8086:08b3'],
+                 device_names={'8086:1559': 'Intel(R) Ethernet Connection I218-V',
+                               '10ec:8168': 'Realtek PCIe GBE Family Controller',
+                               '8086:08b3': 'Intel(R) Dual Band Wireless-AC 3160'})
+    net = {}
+    for r in summary.rows(named):
+        net.setdefault(r['part'], []).append(r)
+    check('a card is named as the machine names it, not as its driver set',
+          [r['what'] for r in net['Wi-Fi']] == ['Intel(R) Dual Band Wireless-AC 3160'],
+          net.get('Wi-Fi'))
+    check('two cards of one kind are both listed, not just the first',
+          len(net['Ethernet']) == 2, net.get('Ethernet'))
+    check('the device id survives however long the note is',
+          all('[' in r['detail'] for rs in
+              (net['Ethernet'], net['Wi-Fi'], net['Bluetooth']) for r in rs), net)
+    check('Intel Wi-Fi says it is built per release, since that is why it is asked',
+          'one build per macOS' in net['Wi-Fi'][0]['detail'], net['Wi-Fi'])
+    check('a set with version-bounded extras says how many',
+          '+3' in net['Bluetooth'][0]['detail'], net['Bluetooth'])
+    check('falling back to the set label when the machine named nothing',
+          summary.rows(dict(named, device_names={}))[3]['what'] == 'Intel Ethernet')
+
+
+def device_names():
+    """The model beside each id, from each source's own shape."""
+    windows = ('PCI\\VEN_8086&DEV_1559&SUBSYS_00011179&REV_04\\3&x|'
+               'Intel(R) Ethernet Connection I218-V')
+    lspci = ('00:19.0 Ethernet controller: Intel Corporation Ethernet Connection '
+             'I218-V [8086:1559] (rev 04)')
+    lsusb = 'Bus 001 Device 004: ID 8087:07dc Intel Corp. Bluetooth wireless interface'
+    check('Windows names the device after the pipe',
+          detect._names(windows, detect.PCI_PATTERNS) ==
+          {'8086:1559': 'Intel(R) Ethernet Connection I218-V'})
+    check('lspci names it before the bracketed id, not the revision after it',
+          detect._names(lspci, detect.PCI_PATTERNS) ==
+          {'8086:1559': 'Intel Corporation Ethernet Connection I218-V'})
+    check('lsusb names it after the id',
+          detect._names(lsusb, detect.USB_PATTERNS) ==
+          {'8087:07dc': 'Intel Corp. Bluetooth wireless interface'})
+    check('a line with no id contributes nothing',
+          detect._names('some heading', detect.PCI_PATTERNS) == {})
+
 
 def tables_match_sources():
     with tempfile.TemporaryDirectory() as tmp:
@@ -347,7 +390,7 @@ def tables_match_sources():
 if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
                     trackpad, framebuffer, boot_args, other_machine, undecodable_output, scripted_answers,
-                    hardware_summary,
+                    hardware_summary, device_names,
                     tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -527,7 +527,7 @@ def main():
         if matched and not manual:
             print(f'\n{BOLD}Network kexts{RESET}')
             advise.report(hw.get('pci_ids', []), hw.get('usb_ids', []),
-                          source or 'the ids you passed')
+                          source or 'the ids you passed', hw.get('device_names'))
         mode = ask(0, 0, 'Add these to the EFI?',
                    [('all', 'Yes, for every macOS version they support'),
                     ('one', 'Yes, for one macOS version only'),

--- a/tools/summary.py
+++ b/tools/summary.py
@@ -24,6 +24,7 @@ import audio
 import detect
 import gpu
 import inputdev
+import netkexts
 
 PROFILES = Path('profiles')
 
@@ -105,21 +106,46 @@ def audio_row(hw):
                f'AppleALC, {layouts} layout' + ('s to try' if layouts != 1 else ''))
 
 
+def _kext_note(match):
+    """What else the driver set for a kext brings, from data/network.toml."""
+    for s in netkexts.sets():
+        if s['match'] == match:
+            extra = len(s['kext']) - 1
+            return f'+{extra} by macOS version' if extra else ''
+    for s in netkexts.variant_sets():
+        if s['match'] == match:
+            # one build per release, which is why setup.py asks which macOS
+            return 'one build per macOS'
+    return ''
+
+
 def network_rows(hw):
     index = advise.load_table()
-    seen = {}
+    names = hw.get('device_names') or {}
+    seen, order = {}, []
     for bus, ids in (('pci', hw.get('pci_ids') or []), ('usb', hw.get('usb_ids') or [])):
         for i in ids:
             for d in index.get((bus, i), []):
-                seen.setdefault(d['role'], (i, d))
+                # keyed on the device, not the role: a machine with both an Intel
+                # and a Realtek NIC has two of them, and hiding one is a lie by
+                # omission about the card the person is looking for
+                key = (d['role'], i)
+                if key in seen:
+                    continue
+                seen[key] = d
+                order.append(key)
     out = []
     for role, label in (('ethernet', 'Ethernet'), ('wifi', 'Wi-Fi'),
                         ('bluetooth', 'Bluetooth')):
-        hit = seen.get(role)
-        if hit:
-            device_id, d = hit
-            out.append(row(label, d['label'], SUPPORTED,
-                           f'{d["kext"]}  [{device_id}]'))
+        hits = [(i, seen[(r, i)]) for r, i in order if r == role]
+        if hits:
+            for device_id, d in hits:
+                # the id goes right after the kext so a long note cannot push
+                # the most useful part of the line off the end
+                note = _kext_note(d['kext'])
+                out.append(row(label, names.get(device_id) or d['label'], SUPPORTED,
+                               f'{d["kext"]}  [{device_id}]'
+                               + (f'  {note}' if note else '')))
         elif hw.get('pci_ids') or hw.get('usb_ids'):
             # the devices were read and none of them matched, which is a fact
             # worth stating: either macOS needs no kext, or the card has to go
@@ -153,7 +179,7 @@ def input_row(hw):
         return row('Trackpad', name, SUPPORTED, f'VoodooI2C  [{", ".join(i2c)}]')
     if hw.get('ps2'):
         return row('Trackpad', name, SUPPORTED,
-                   'on PS/2, which VoodooPS2 in the laptop profile covers')
+                   'on PS/2; VoodooPS2 is in the laptop profile')
     return row('Trackpad', name, UNKNOWN, 'no I2C controller and nothing on PS/2')
 
 
@@ -169,7 +195,7 @@ def peripheral_rows(hw):
                            'not on USB, so an IPU or MIPI sensor'))
     for dev in [d for d in real if d['kind'] == 'card reader']:
         out.append(row('Card reader', dev['name'], UNKNOWN,
-                       'this repository has no support data for card readers'))
+                       'no support data for card readers here'))
     return out
 
 
@@ -203,7 +229,7 @@ def render(hw, source='this machine'):
         what = _fit(r['what'], width)
         # the long form of a verdict belongs in the section that acts on it; here
         # a line that wraps costs more than the words at the end are worth
-        detail = _fit(r['detail'], 46)
+        detail = _fit(r['detail'], 52)
         colour = COLOUR[r['verdict']]
         lines.append(f'  {r["part"]:<12s} {what:<{width}s}  '
                      f'{colour}{r["verdict"]:<14s}{RESET}{DIM}{detail}{RESET}'.rstrip())


### PR DESCRIPTION
The summary said `Intel Ethernet` and `Intel Wi-Fi`. Those are the labels of the
driver sets in `data/network.toml`, not the cards. The machine had already
printed the models and they were being thrown away:

```
Ethernet     Intel(R) Ethernet Connection I218-V   supported   IntelMausi.kext  [8086:1559]
Wi-Fi        Intel(R) Dual Band Wireless-AC 3160   supported   AirportItlwm.kext  [8086:08b3]  one build per macOS
Bluetooth    Intel(R) Wireless Bluetooth(R)        supported   IntelBluetoothFirmware.kext  [8087:07dc]  +3 by macOS version
```

Every source prints the model beside the id, each in its own place: after the
pipe on Windows, before the bracketed id in `lspci -nn`, after it in `lsusb`.
`detect._names` reads all three and `probe()` carries the result as
`device_names`, which travels in a report the way the ids do - a model name is
not a serial number. `advise.py` uses it too, so the report after the build
names the cards as well.

Three other things the row was not saying:

* **One row per device, not per role.** A machine with both an Intel and a
  Realtek NIC showed only the first, which is a lie by omission about exactly
  the card someone is looking for.
* **Intel Wi-Fi is built separately for each macOS.** That is why setup asks
  which release, and the row now says so rather than leaving the question to
  come out of nowhere later.
* **A set with version-bounded extras says how many.** Bluetooth is four kexts
  with Darwin bounds, not one.

The id now comes straight after the kext name so no note can push it off the end
of a truncated line.