### PR TITLE
Tell PyInstaller about what it cannot see

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -125,6 +125,9 @@ jobs:
           test -d /tmp/by-name/EFI/OC/Kexts/IntelBluetoothFirmware.kext
           test ! -d /tmp/by-name/EFI/OC/Kexts/AirportItlwm.kext
 
+      - name: The vendored tools load
+        run: python3 tools/setup.py --check-tools
+
       - name: The vendored ACPI tools are the files that were checked
         run: |
           python3 - <<'CHECK'

--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -32,6 +32,18 @@ jobs:
       - name: And detection runs without throwing
         run: dist/HackintoshEFIBuilder.exe --answers 1,2,10,3,3 --out smoke2/EFI
 
+      # SSDTTime is imported at runtime, so PyInstaller cannot see what it
+      # imports. A missing module does not show until somebody answers yes to a
+      # question, which is how it was found the first time. This answers it.
+      - name: The vendored tools load inside the frozen build
+        run: dist/HackintoshEFIBuilder.exe --check-tools
+
+      - name: It can dump this runner's ACPI tables and compile against them
+        run: |
+          dist/HackintoshEFIBuilder.exe --report machine.json --acpi ACPI
+          if (-not (Test-Path machine.json)) { exit 1 }
+          Get-ChildItem ACPI | Select-Object -First 5 Name
+
       - uses: actions/upload-artifact@v4
         with:
           name: windows-exe

--- a/tools/README.md
+++ b/tools/README.md
@@ -815,7 +815,18 @@ is allowed to pass.
 `--machine tools/fixtures/no-hardware.json`. That is what CI uses,
 on both platforms, instead of piping keystrokes.
 
-Two things the frozen build gets wrong if written the obvious way, both fixed:
+A third: **PyInstaller only bundles what it can see being imported.** SSDTTime
+is loaded at runtime with `importlib`, from a copy of the vendored tree, so its
+imports are invisible to the analysis and none of the standard library it uses
+gets bundled. The frozen build then dies the moment somebody answers yes to the
+SSDT question - `No module named 'shlex'` - which is exactly how it was found,
+on a real machine, after CI had passed. Every module the tree imports is now
+named in the spec, a self-test reads them back out of the tree and fails if one
+is missing, and `--check-tools` loads the tools so the Windows job can answer
+that question against the executable it just built instead of waiting for a
+person to.
+
+Two other things the frozen build gets wrong if written the obvious way:
 a relative script path in the spec resolves against the spec's own directory, so
 `tools/setup.py` in a spec that lives in `tools/` looks for `tools/tools/`; and
 `sys.executable` is the executable itself rather than an interpreter, so

--- a/tools/pyinstaller.spec
+++ b/tools/pyinstaller.spec
@@ -19,10 +19,22 @@ a = Analysis(
     [os.path.join(TOOLS, 'setup.py')],
     pathex=[TOOLS],
     datas=datas,
-    hiddenimports=['advise', 'audio', 'build', 'detect', 'gpu', 'igpu',
+    hiddenimports=['acpi', 'advise', 'audio', 'build', 'detect', 'gpu', 'igpu',
                    'inputdev', 'itlwm', 'netkexts', 'ocgen', 'provenance',
-                   'acpi', 'thirdparty', 'usbmap',
-                   'summary'],
+                   'summary', 'thirdparty', 'usbmap']
+                  # SSDTTime is loaded at runtime with importlib, from a copy of
+                  # the vendored tree. PyInstaller never sees those imports, so
+                  # the standard library it uses has to be named here or the
+                  # frozen build dies the moment somebody says yes to SSDTs -
+                  # which is exactly how this was found.
+                  + ['binascii', 'ctypes', 'datetime', 'errno', 'getpass', 'glob',
+                     'msvcrt', 'os', 'sys',
+                     'gzip', 'io', 'itertools', 'json', 'multiprocessing',
+                     'plistlib', 'queue', 're', 'select', 'shlex', 'shutil',
+                     'ssl', 'string', 'struct', 'subprocess', 'tempfile',
+                     'textwrap', 'threading', 'time', 'urllib', 'urllib.error',
+                     'urllib.parse', 'urllib.request', 'xml', 'xml.etree',
+                     'xml.etree.ElementTree', 'zipfile'],
     excludes=['tkinter', 'unittest', 'pydoc_data', 'test'],
 )
 pyz = PYZ(a.pure)

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -8,6 +8,7 @@ the whole file before a single step runs - which is exactly what happened.
 """
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -574,6 +575,28 @@ def native_device_ids():
           gpu.native_ids('rocket-lake') == set())
 
 
+def frozen_build():
+    """What PyInstaller cannot see, and therefore has to be told."""
+    import ast
+    spec = Path('tools/pyinstaller.spec').read_text()
+    named = set(re.findall(r"'([\w.]+)'", spec))
+    wanted = set()
+    for f in sorted(Path('vendor/tools/SSDTTime').rglob('*.py')):
+        for node in ast.walk(ast.parse(f.read_text(encoding='utf-8', errors='replace'))):
+            if isinstance(node, ast.Import):
+                wanted |= {a.name.split('.')[0] for a in node.names}
+            elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
+                wanted.add(node.module.split('.')[0])
+    # only the standard library: the Python 2 fallbacks in its try blocks are
+    # not there to be found, and the frozen build is Python 3
+    wanted = {m for m in wanted if m in sys.stdlib_module_names}
+    missing = sorted(wanted - named)
+    check('every module SSDTTime imports is named in the spec', not missing, missing)
+
+    r = run([sys.executable, 'tools/setup.py', '--check-tools'])
+    check('and the builder can load the tools on demand', r.returncode == 0)
+
+
 def acpi_tables():
     """SSDTTime is driven, not reimplemented, so the wiring is what is checked."""
     import acpi
@@ -882,7 +905,7 @@ if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
                     trackpad, framebuffer, boot_args, other_machine, undecodable_output, scripted_answers,
                     hardware_summary, device_names, broadcom_wifi,
-                    detection_gaps, provenance, framebuffers, native_device_ids, field_reports, macos_window, card_readers, third_party, usb_mapping, acpi_tables,
+                    detection_gaps, provenance, framebuffers, native_device_ids, field_reports, macos_window, card_readers, third_party, usb_mapping, acpi_tables, frozen_build,
                     tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -158,6 +158,54 @@ def unbundle():
     return here
 
 
+def check_tools():
+    """Load every vendored tool, which is the thing a frozen build gets wrong.
+
+    SSDTTime is imported at runtime from a copy of its tree, so PyInstaller
+    cannot see what it imports and does not bundle it. Nothing catches that
+    until somebody answers yes to a question - so this answers it instead, and
+    CI runs it against the executable it just built."""
+    import tempfile
+    failed = []
+
+    def report(name, ok, detail=''):
+        print(f'  {"ok  " if ok else "FAIL"}  {name}' + (f'   {detail}' if detail else ''))
+        if not ok:
+            failed.append(name)
+
+    if usbmap.available():
+        ok, detail = usbmap.verify(usbmap.available())
+        report('the USB mapper is the file that was checked', ok, '' if ok else detail)
+    else:
+        report('the USB mapper is here', False, 'it is not')
+
+    if acpi.available():
+        ok, detail = acpi.verify()
+        report('every ACPI compiler is the file that was checked', ok,
+               '' if ok else detail)
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                work = acpi.prepare(Path(tmp) / 'acpi')
+                module = acpi.load(work)
+                ssdt = module.SSDT()
+                report('SSDTTime loads, with everything it imports', True)
+                report('and finds the compiler beside it', bool(ssdt.d.iasl),
+                       '' if ssdt.d.iasl else 'it did not')
+                report('and the legacy one, so it never downloads',
+                       bool(ssdt.d.iasl_legacy))
+        except Exception as exc:                   # noqa: BLE001 - the whole point
+            report('SSDTTime loads, with everything it imports', False, repr(exc))
+    else:
+        report('SSDTTime is usable here', False, f'not on {sys.platform}')
+
+    print()
+    if failed:
+        print(f'  {len(failed)} failed: {", ".join(failed)}')
+        return 1
+    print('  all good')
+    return 0
+
+
 def profile_from(hw):
     """(platform, vendor, cpu, cores, oem) when detection answers all of it.
 
@@ -305,6 +353,9 @@ def main():
                          'EFI for it can be built elsewhere')
     ap.add_argument('--check', action='store_true',
                     help='print what the hardware means for macOS and stop')
+    ap.add_argument('--check-tools', action='store_true',
+                    help='load the vendored tools and stop, which is what a '
+                         'frozen build has to be able to do')
     ap.add_argument('--ids', help='PCI ids to use instead of probing, comma separated')
     ap.add_argument('--usb-ids', help='USB ids to use instead of probing, comma separated')
     ap.add_argument('--hda-ids', help='HD audio codec ids to use instead of probing')
@@ -328,6 +379,9 @@ def main():
         for opt in ('machine', 'report', 'usb_map'):
             if getattr(a, opt):
                 setattr(a, opt, str((started_in / getattr(a, opt)).resolve()))
+
+    if a.check_tools:
+        return check_tools()
 
     if a.report:
         a.report = str(Path(a.report).expanduser().resolve())


### PR DESCRIPTION
The frozen build died on `No module named 'shlex'` the moment somebody answered
yes to the SSDT question. Found on a real machine, after CI had passed.

**PyInstaller only bundles what it can see being imported.** SSDTTime is loaded
at runtime with `importlib`, from a copy of the vendored tree, so its imports
are invisible to the analysis and none of the standard library it uses was
bundled. Every module the tree imports is now named in the spec - 35 of them,
read out of the tree rather than guessed at.

Two things so this cannot come back quietly:

* A self-test parses every `.py` under `vendor/tools/SSDTTime`, collects what it
  imports, and fails if one is not named in the spec. That caught three more
  after the first fix - `msvcrt`, `os` and `sys` - which are always present in
  practice, but the test cannot know that and neither should the spec.
* `setup.py --check-tools` loads both vendored tools and reports. The Windows
  job now runs it against the executable it just built, so the question gets
  answered in CI instead of waiting for a person to answer it on their machine.

The Windows job also now takes a hardware report with `--acpi`, which exercises
`acpidump.exe` on a real Windows for the first time.

Nothing else changed: no data, no config, no behaviour outside the frozen build.