### PR TITLE
Spell the flags CI passes in full

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -40,9 +40,17 @@ jobs:
 
       - name: It can dump this runner's ACPI tables and compile against them
         run: |
-          dist/HackintoshEFIBuilder.exe --report machine.json --acpi ACPI
+          # the report dumps the tables beside itself; there is no flag for it,
+          # and --acpi is ambiguous with --acpi-ids and --acpi-tables
+          dist/HackintoshEFIBuilder.exe --report machine.json
           if (-not (Test-Path machine.json)) { exit 1 }
-          Get-ChildItem ACPI | Select-Object -First 5 Name
+          if (-not (Test-Path ACPI)) { Write-Error 'no ACPI tables were dumped'; exit 1 }
+          Get-ChildItem ACPI | Select-Object -First 8 Name
+          if (-not (Test-Path ACPI/DSDT.aml)) { Write-Error 'no DSDT'; exit 1 }
+          # and the tables it just dumped are the ones a build would use
+          dist/HackintoshEFIBuilder.exe --machine machine.json --acpi-tables ACPI `
+            --answers 1,2,10,3,3 --out acpi-smoke/EFI
+          if (-not (Test-Path acpi-smoke/EFI/OC/config.plist)) { exit 1 }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -575,6 +575,44 @@ def native_device_ids():
           gpu.native_ids('rocket-lake') == set())
 
 
+def workflow_flags():
+    """Every flag CI passes has to be one the tool actually has, spelled in full.
+
+    argparse accepts an unambiguous prefix, so --acpi worked until --acpi-ids
+    and --acpi-tables both existed and it became "ambiguous option". Nothing
+    fails at the point the flag is added; it fails later, in a job that only
+    runs on dispatch."""
+    import ast
+    declared = {}
+    for tool in sorted(Path('tools').glob('*.py')):
+        names = set()
+        for node in ast.walk(ast.parse(tool.read_text())):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == 'add_argument'):
+                for arg in node.args:
+                    if isinstance(arg, ast.Constant) and str(arg.value).startswith('--'):
+                        names.add(arg.value)
+        if names:
+            declared[tool.name] = names | {'--help'}
+
+    used, bad = 0, []
+    for wf in sorted(Path('.github/workflows').glob('*.yml')):
+        for line in wf.read_text().splitlines():
+            line = line.strip()
+            if line.startswith('#'):
+                continue
+            for tool, names in declared.items():
+                if f'tools/{tool}' not in line and not (
+                        tool == 'setup.py' and 'HackintoshEFIBuilder.exe' in line):
+                    continue
+                for flag in re.findall(r'(?<![\w-])--[a-z][a-z-]*', line):
+                    used += 1
+                    if flag not in names:
+                        bad.append(f'{wf.name}: {flag} is not a flag of {tool}')
+    check('every flag the workflows pass is spelled in full', not bad, bad)
+    check('and there were flags to check', used > 20, used)
+
+
 def frozen_build():
     """What PyInstaller cannot see, and therefore has to be told."""
     import ast
@@ -905,7 +943,7 @@ if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
                     trackpad, framebuffer, boot_args, other_machine, undecodable_output, scripted_answers,
                     hardware_summary, device_names, broadcom_wifi,
-                    detection_gaps, provenance, framebuffers, native_device_ids, field_reports, macos_window, card_readers, third_party, usb_mapping, acpi_tables, frozen_build,
+                    detection_gaps, provenance, framebuffers, native_device_ids, field_reports, macos_window, card_readers, third_party, usb_mapping, acpi_tables, frozen_build, workflow_flags,
                     tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -393,7 +393,7 @@ def main():
         # travel with the report rather than being asked for later
         tables = None
         if acpi.available() and acpi.platform_key() != 'darwin':
-            beside = Path(a.report).with_suffix('') .parent / 'ACPI'
+            beside = Path(a.report).parent / 'ACPI'
             tables, complaint = acpi.dump(Path(a.out).parent / 'acpi-dump', beside)
             print(f'  {"and its ACPI tables to " + str(beside) if tables else complaint}')
         print(f'\n  Copy {"them" if tables else "it"} to the machine you build on '


### PR DESCRIPTION
The Windows job failed on `ambiguous option: --acpi could match --acpi-ids,
--acpi-tables`. The line was wrong from the start: `--acpi` is `detect.py`'s
flag, and `setup.py` dumps the tables beside the report with no flag at all.

Good news from the same run: `--check-tools` passed all five inside the frozen
build, so SSDTTime and both compilers load on Windows.

Fixed, and then made unrepeatable. argparse accepts an unambiguous prefix, so
`--acpi` worked right up until `--acpi-ids` and `--acpi-tables` both existed -
nothing fails when the flag is added, it fails later, in a job that only runs on
dispatch. A self-test now reads every `--flag` out of every `add_argument` in
`tools/`, reads every flag the workflows pass, and fails on anything that is not
an exact match. Reintroducing `--acpi` makes it say so:

```
FAIL  every flag the workflows pass is spelled in full   ['windows-exe.yml: --acpi is not a flag of setup.py']
```

The Windows job now also checks the dump produced a DSDT and then builds an EFI
against those tables, so `acpidump.exe` and the report-plus-tables flow are both
exercised rather than only started.

Also tidied: `Path(a.report).with_suffix('').parent` was a roundabout way of
writing `Path(a.report).parent`.