### PR TITLE
Stop the Windows job answering a machine it cannot predict

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -29,8 +29,12 @@ jobs:
           dist/HackintoshEFIBuilder.exe --no-detect --answers 2,10,3 --out smoke/EFI
           if (-not (Test-Path smoke/EFI/OC/config.plist)) { exit 1 }
 
+      # --check reads this runner and prints what it means, with no questions
+      # to answer. A fixed answer string against whatever the runner happens to
+      # be is what broke this job: a Hyper-V Xeon takes a different path through
+      # the menus than a laptop does.
       - name: And detection runs without throwing
-        run: dist/HackintoshEFIBuilder.exe --answers 1,2,10,3,3 --out smoke2/EFI
+        run: dist/HackintoshEFIBuilder.exe --check
 
       # SSDTTime is imported at runtime, so PyInstaller cannot see what it
       # imports. A missing module does not show until somebody answers yes to a
@@ -47,9 +51,12 @@ jobs:
           if (-not (Test-Path ACPI)) { Write-Error 'no ACPI tables were dumped'; exit 1 }
           Get-ChildItem ACPI | Select-Object -First 8 Name
           if (-not (Test-Path ACPI/DSDT.aml)) { Write-Error 'no DSDT'; exit 1 }
-          # and the tables it just dumped are the ones a build would use
-          dist/HackintoshEFIBuilder.exe --machine machine.json --acpi-tables ACPI `
-            --answers 1,2,10,3,3 --out acpi-smoke/EFI
+          # and the tables it just dumped are the ones a build would use.
+          # The machine is the fixture, not this runner: a Hyper-V Xeon answers
+          # a different set of questions than a laptop does, and a fixed answer
+          # string against whatever the runner happens to be is how this failed.
+          dist/HackintoshEFIBuilder.exe --machine tools/fixtures/no-hardware.json `
+            --acpi-tables ACPI --answers 2,10,3 --out acpi-smoke/EFI
           if (-not (Test-Path acpi-smoke/EFI/OC/config.plist)) { exit 1 }
 
       - uses: actions/upload-artifact@v4

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -613,6 +613,44 @@ def workflow_flags():
     check('and there were flags to check', used > 20, used)
 
 
+def runner_independence():
+    """No job may answer menus against whatever machine it lands on.
+
+    A fixed --answers string only means one thing if the questions are fixed,
+    and they are not: they depend on what was detected. The Windows job answered
+    a laptop's questions on a Hyper-V Xeon and ran out halfway."""
+    bad = []
+    for wf in sorted(Path('.github/workflows').glob('*.yml')):
+        # a command can be split over lines with a backslash or a backtick, and
+        # the --machine that makes it deterministic is often on the first of them
+        joined, buffer = [], ''
+        for number, line in enumerate(wf.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith('#'):
+                continue
+            start = number if not buffer else start          # noqa: F821 - set below
+            buffer += ' ' + stripped
+            if stripped.endswith(('\\', '`')):
+                continue
+            joined.append((start, buffer))
+            buffer = ''
+        for number, command in joined:
+            if '--answers' not in command:
+                continue
+            answers = re.search(r'--answers\s+(\S+)', command)
+            first = answers.group(1).split(',')[0] if answers else ''
+            fixed = ('--machine' in command or '--no-detect' in command
+                     or re.search(r'\$[A-Z0-9]+', command)
+                     # 2 and 3 at the scope question are "another machine", which
+                     # takes the report or the by-name path and detects nothing
+                     or first in ('2', '3'))
+            if not fixed:
+                bad.append(f'{wf.name}:{number} {command.strip()[:70]}')
+    # no exceptions: the one job that wanted to build from real detection uses
+    # --check instead, which asks nothing
+    check('no job answers menus against a machine it cannot predict', not bad, bad)
+
+
 def frozen_build():
     """What PyInstaller cannot see, and therefore has to be told."""
     import ast
@@ -944,6 +982,7 @@ if __name__ == '__main__':
                     trackpad, framebuffer, boot_args, other_machine, undecodable_output, scripted_answers,
                     hardware_summary, device_names, broadcom_wifi,
                     detection_gaps, provenance, framebuffers, native_device_ids, field_reports, macos_window, card_readers, third_party, usb_mapping, acpi_tables, frozen_build, workflow_flags,
+                    runner_independence,
                     tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -376,7 +376,10 @@ def main():
     started_in = unbundle()
     if started_in:
         a.out = str((started_in / a.out).resolve())
-        for opt in ('machine', 'report', 'usb_map'):
+        # every path a caller passes is theirs, not the bundle's. Leaving
+        # acpi_tables out of this meant the frozen build looked for the dumped
+        # tables inside its own unpacked copy, where they never are.
+        for opt in ('machine', 'report', 'usb_map', 'acpi_tables'):
             if getattr(a, opt):
                 setattr(a, opt, str((started_in / getattr(a, opt)).resolve()))
 


### PR DESCRIPTION
The Windows job answered a laptop's questions on a Hyper-V Xeon and ran out
halfway. My CI line's fault, and the same mistake I fixed in `validate` weeks
ago and then reintroduced here.

A fixed `--answers` string only means one thing if the questions are fixed, and
they are not - they depend on what was detected. On that runner, `--machine
machine.json` (its own report) gave Desktop, my `2` picked AMD, and the AMD
generation menu has two options where I had passed `10`.

* The ACPI smoke build now uses `tools/fixtures/no-hardware.json`, so the
  questions are the same on every runner. It still uses the tables the runner
  just dumped, which is the part being tested.
* "Detection runs without throwing" is now `--check`, which reads the runner and
  prints what it means with nothing to answer. That was the only job left
  building from real detection.
* A self-test joins each workflow's continued lines and fails on any `--answers`
  that is not pinned by `--machine`, `--no-detect`, a fixture variable, or a
  scope answer that means "another machine". No exceptions allowed. Putting the
  old line back makes it say so.

Also fixed, and it would have broken the same step one line later: `acpi_tables`
was missing from the list of paths resolved against where the person actually
is, so the frozen build looked for the dumped tables inside its own unpacked
copy, where they never are.

From the run before this one: `--check-tools` passed all five inside the frozen
build, and `acpidump.exe` dumped DSDT, FACP, APIC and five more on a real
Windows. Those two were the parts I could not test here.