### PR TITLE
Put back the names a frozen build takes away

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -826,6 +826,21 @@ is missing, and `--check-tools` loads the tools so the Windows job can answer
 that question against the executable it just built instead of waiting for a
 person to.
 
+A fourth, which only shows at the very end of a session: **PyInstaller does not
+run `site.py`, so `exit` and `quit` do not exist.** SSDTTime quits with
+`exit(0)`. Unfrozen that is a `SystemExit` and is caught; frozen it is a
+`NameError`, unhandled, and the whole builder dies the moment somebody finishes
+making their SSDTs and presses Q - taking the EFI they were about to get with
+it. The names are put back before the tool is loaded, which is restoring what
+the interpreter normally provides rather than patching somebody else's code, and
+nothing the tool throws is left to reach the builder any more.
+
+A fifth, found by building a frozen binary here and running `--check-tools` in
+it: **PyInstaller rewrites the binaries it bundles.** It re-signs Mach-O files,
+so the hash of a vendored compiler inside the bundle is not the hash that was
+committed. The lock pins the repository copy and CI checks it there; inside a
+frozen build the check says so rather than passing quietly or failing wrongly.
+
 Two other things the frozen build gets wrong if written the obvious way:
 a relative script path in the spec resolves against the spec's own directory, so
 `tools/setup.py` in a spec that lives in `tools/` looks for `tools/tools/`; and

--- a/tools/acpi.py
+++ b/tools/acpi.py
@@ -74,7 +74,7 @@ def available():
 
 
 def verify():
-    """(ok, complaint) - the binaries have to be the ones that were checked."""
+    """(ok, detail) - the binaries have to be the ones that were checked."""
     if not LOCK.exists():
         return False, f'{LOCK} is missing'
     lock = ocgen.read_toml(LOCK)['tool']
@@ -82,11 +82,28 @@ def verify():
         entry = lock.get(f'iasl/{src}')
         if not entry:
             return False, f'iasl/{src} is not in {LOCK}'
+        if not (IASL / src).exists():
+            return False, f'{IASL / src} is missing'
+        if getattr(sys, 'frozen', False):
+            continue
         got = hashlib.sha256((IASL / src).read_bytes()).hexdigest()
         if got != entry['sha256']:
             return False, (f'{IASL / src} does not match {LOCK}; expected '
                            f'{entry["sha256"][:12]}, found {got[:12]}')
-    return True, lock['SSDTTime']['version']
+    version = lock['SSDTTime']['version']
+    return True, (f'{version}, {hash_note()}' if getattr(sys, 'frozen', False)
+                  else version)
+
+def hash_note():
+    """Why a hash is not checked inside a frozen build.
+
+    PyInstaller rewrites the binaries it bundles - it re-signs Mach-O files, so
+    what is unpacked is not byte for byte what was committed. The hash pins what
+    is in the repository and CI checks it there; once the packer has been over
+    it the guarantee belongs to the build, not to a check at run time. Saying so
+    is better than a check that passes because it was quietly skipped."""
+    return 'not hashed here: the packer rewrote it, so CI checks the repository copy'
+
 
 
 def prepare(work):
@@ -103,8 +120,36 @@ def prepare(work):
     return work
 
 
+def restore_site_builtins():
+    """Put back the names a frozen build takes away.
+
+    SSDTTime quits with `exit(0)`. That name comes from site.py, which
+    PyInstaller does not run, so in the frozen build it is a NameError rather
+    than a SystemExit - and an unhandled one, which killed the whole builder the
+    moment somebody finished making their SSDTs. Restoring the name is putting
+    back what the interpreter normally provides, not patching their code."""
+    import builtins
+    for name in ('exit', 'quit'):
+        if not hasattr(builtins, name):
+            setattr(builtins, name, _Quitter(name))
+
+
+class _Quitter:
+    """What site.py installs: calling it raises SystemExit."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f'Use {self.name}() to exit'
+
+    def __call__(self, code=None):
+        raise SystemExit(code)
+
+
 def load(work):
     """Import SSDTTime from the copy, so its own __file__ is in our directory."""
+    restore_site_builtins()
     sys.path.insert(0, str(work))
     spec = importlib.util.spec_from_file_location('SSDTTime', work / 'SSDTTime.py')
     module = importlib.util.module_from_spec(spec)
@@ -133,6 +178,10 @@ def run(work, tables=None):
             ssdt.main()
     except SystemExit:
         pass
+    except BaseException as exc:                   # noqa: BLE001
+        # a half-finished EFI is not worth losing to the tool falling over, and
+        # whatever went wrong is worth naming rather than swallowing
+        print(f'  SSDTTime stopped: {exc!r}')
     finally:
         os.chdir(here)
         if str(work) in sys.path:

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -673,6 +673,40 @@ def frozen_build():
     check('and the builder can load the tools on demand', r.returncode == 0)
 
 
+def frozen_names():
+    """Names a frozen build takes away, which the vendored code still uses.
+
+    PyInstaller does not run site.py, so `exit` and `quit` do not exist. SSDTTime
+    quits with `exit(0)`: unfrozen that is a SystemExit and is caught, frozen it
+    is a NameError that killed the whole builder the moment somebody finished
+    making their SSDTs. Reproduced with a one-line frozen probe before fixing."""
+    import builtins
+    import acpi
+    had = {n: getattr(builtins, n, None) for n in ('exit', 'quit')}
+    try:
+        for name in had:
+            if hasattr(builtins, name):
+                delattr(builtins, name)
+        acpi.restore_site_builtins()
+        check('exit is put back when it is not there', hasattr(builtins, 'exit'))
+        try:
+            builtins.exit(0)
+            check('and calling it raises SystemExit', False, 'it returned')
+        except SystemExit:
+            check('and calling it raises SystemExit', True)
+        except BaseException as exc:                # noqa: BLE001
+            check('and calling it raises SystemExit', False, repr(exc))
+    finally:
+        for name, value in had.items():
+            if value is not None:
+                setattr(builtins, name, value)
+
+    # the tool must not take the builder down with it whatever it does
+    src = Path('tools/acpi.py').read_text()
+    check('and nothing the tool throws is left to reach the builder',
+          'except BaseException' in src)
+
+
 def acpi_tables():
     """SSDTTime is driven, not reimplemented, so the wiring is what is checked."""
     import acpi
@@ -979,11 +1013,13 @@ def tables_match_sources():
 
 if __name__ == '__main__':
     for section in (graphics, graphics_advice, audio_advice, storage, peripherals,
-                    trackpad, framebuffer, boot_args, other_machine, undecodable_output, scripted_answers,
-                    hardware_summary, device_names, broadcom_wifi,
-                    detection_gaps, provenance, framebuffers, native_device_ids, field_reports, macos_window, card_readers, third_party, usb_mapping, acpi_tables, frozen_build, workflow_flags,
-                    runner_independence,
-                    tables_match_sources):
+                    trackpad, framebuffer, boot_args, other_machine,
+                    undecodable_output, scripted_answers, hardware_summary,
+                    device_names, broadcom_wifi, detection_gaps, provenance,
+                    framebuffers, native_device_ids, field_reports, macos_window,
+                    card_readers, third_party, usb_mapping, acpi_tables,
+                    frozen_names, frozen_build, workflow_flags,
+                    runner_independence, tables_match_sources):
         print(f'\n{section.__name__}')
         section()
     print()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -175,20 +175,35 @@ def check_tools():
 
     if usbmap.available():
         ok, detail = usbmap.verify(usbmap.available())
-        report('the USB mapper is the file that was checked', ok, '' if ok else detail)
+        report('the USB mapper is the file that was checked', ok, detail)
     else:
         report('the USB mapper is here', False, 'it is not')
 
     if acpi.available():
         ok, detail = acpi.verify()
-        report('every ACPI compiler is the file that was checked', ok,
-               '' if ok else detail)
+        report('every ACPI compiler is the file that was checked', ok, detail)
         try:
             with tempfile.TemporaryDirectory() as tmp:
                 work = acpi.prepare(Path(tmp) / 'acpi')
                 module = acpi.load(work)
                 ssdt = module.SSDT()
                 report('SSDTTime loads, with everything it imports', True)
+                # it quits with exit(0), which a frozen build does not have.
+                # That killed the whole builder the first time somebody
+                # finished their SSDTs, so it is asked here instead.
+                try:
+                    # it prints a goodbye on the way out, which is not wanted here
+                    import contextlib
+                    import io
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        ssdt.u.custom_quit()
+                    report('quitting it raises SystemExit, not something fatal',
+                           False, 'it returned instead')
+                except SystemExit:
+                    report('quitting it raises SystemExit, not something fatal', True)
+                except BaseException as exc:      # noqa: BLE001 - the whole point
+                    report('quitting it raises SystemExit, not something fatal',
+                           False, repr(exc))
                 report('and finds the compiler beside it', bool(ssdt.d.iasl),
                        '' if ssdt.d.iasl else 'it did not')
                 report('and the legacy one, so it never downloads',

--- a/tools/usbmap.py
+++ b/tools/usbmap.py
@@ -48,10 +48,20 @@ def available():
 
 
 def verify(path):
-    """(ok, complaint) - the file has to be the one that was checked."""
+    """(ok, detail) - the file has to be the one that was checked.
+
+    PyInstaller rewrites the binaries it bundles, so inside a frozen build what
+    is unpacked is not byte for byte what was committed. The hash pins the
+    repository copy and CI checks it there; here the guarantee belongs to the
+    build, and that is said rather than skipped quietly."""
     entry = ocgen.read_toml(LOCK)['tool'].get(TOOL)
     if not entry:
         return False, f'{TOOL} is not in {LOCK}'
+    if not path.exists():
+        return False, f'{path} is missing'
+    if getattr(sys, 'frozen', False):
+        return True, (f'{entry["version"]}, not hashed here: the packer rewrote '
+                      f'it, so CI checks the repository copy')
     got = hashlib.sha256(path.read_bytes()).hexdigest()
     if got != entry['sha256']:
         return False, (f'{path} does not match the hash in {LOCK}; '


### PR DESCRIPTION
You made your SSDTs, pressed Q, and the whole builder vanished. Reproduced,
found, fixed, and proved in a real frozen binary.

**PyInstaller does not run `site.py`, so `exit` and `quit` do not exist.**
SSDTTime quits with `exit(0)`. Unfrozen that is a `SystemExit` and `acpi.run`
catches it; frozen it is a `NameError`, unhandled, and the process dies - taking
the EFI you were one step away from with it. A one-line frozen probe says it
plainly:

```
frozen      : True
has exit    : False
exit(0) -> NameError: name 'exit' is not defined
```

The names are put back before the tool is loaded. That is restoring what the
interpreter normally provides, not patching somebody else's code. And nothing
the tool throws is left to reach the builder any more: a half-finished EFI is
not worth losing to a tool falling over, and whatever went wrong is named rather
than swallowed.

`--check-tools` now presses Q itself, so CI answers the question instead of
waiting for a person to find it the hard way.

## A second thing, found by building a frozen binary here

I built one with PyInstaller on this machine and ran `--check-tools` in it,
which is as close to your Windows as I can get. It failed on something else:

```
FAIL  every ACPI compiler is the file that was checked
      vendor/tools/iasl/macos/iasl-stable does not match vendor/tools.lock
```

**PyInstaller rewrites the binaries it bundles** - it re-signs Mach-O files, so
what is unpacked is not byte for byte what was committed. The hash was checking
a file the packer had been over. The lock pins the repository copy and CI checks
it there; inside a frozen build the check now says so:

```
ok  every ACPI compiler is the file that was checked   3b195df, not hashed here:
    the packer rewrote it, so CI checks the repository copy
```

Not skipped quietly, and not failed wrongly. A missing file is still a failure.

Windows did not hit this, which is why its job passed - the packer leaves PE
files alone. It would have hit it the first time anyone built the exe on macOS.