### PR TITLE
Keep the window open long enough to read

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -815,7 +815,15 @@ is allowed to pass.
 `--machine tools/fixtures/no-hardware.json`. That is what CI uses,
 on both platforms, instead of piping keystrokes.
 
-A third: **PyInstaller only bundles what it can see being imported.** SSDTTime
+A third, and it is not a bug in the packer: **a console the program opened for
+itself dies with it.** Somebody who double-clicks the executable gets a window
+that flashes and closes, taking the build summary, the warnings and the path to
+the EFI with it. The frozen build waits for a key before it exits - only the
+frozen build, only on a terminal, and never under `--answers`, which would hang
+CI. A refusal is printed before the pause rather than after, since being able to
+read it is the point.
+
+A fourth: **PyInstaller only bundles what it can see being imported.** SSDTTime
 is loaded at runtime with `importlib`, from a copy of the vendored tree, so its
 imports are invisible to the analysis and none of the standard library it uses
 gets bundled. The frozen build then dies the moment somebody answers yes to the
@@ -841,7 +849,7 @@ so the hash of a vendored compiler inside the bundle is not the hash that was
 committed. The lock pins the repository copy and CI checks it there; inside a
 frozen build the check says so rather than passing quietly or failing wrongly.
 
-Two other things the frozen build gets wrong if written the obvious way:
+Two more things the frozen build gets wrong if written the obvious way:
 a relative script path in the spec resolves against the spec's own directory, so
 `tools/setup.py` in a spec that lives in `tools/` looks for `tools/tools/`; and
 `sys.executable` is the executable itself rather than an interpreter, so

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -673,6 +673,29 @@ def frozen_build():
     check('and the builder can load the tools on demand', r.returncode == 0)
 
 
+def window_stays_open():
+    """A console the program opened for itself dies with it, taking the summary.
+
+    Somebody who double-clicks the executable sees a window flash and nothing
+    else: the warnings, the path to the EFI and the ROM reminder all go with it.
+    So the frozen build waits for a key - and only the frozen build, only on a
+    terminal, and never under --answers, or CI would hang."""
+    import setup as guided
+    src = Path('tools/setup.py').read_text()
+    check('the pause is only for the frozen build',
+          "if not getattr(sys, 'frozen', False) or SCRIPTING:" in src)
+    check('and a refusal is printed before it, not swallowed',
+          'if isinstance(exc.code, str):' in src)
+
+    # unfrozen, it must be a no-op whatever stdin is
+    check('nothing waits when running from a clone', guided.hold() is None)
+
+    r = run([sys.executable, 'tools/setup.py', '--machine', '/tmp/nope.json'],
+            may_fail=True)
+    check('a refusal still exits non-zero', r.returncode == 1, r.returncode)
+    check('and says why', 'does not exist' in (r.stdout + r.stderr))
+
+
 def frozen_names():
     """Names a frozen build takes away, which the vendored code still uses.
 
@@ -1018,7 +1041,7 @@ if __name__ == '__main__':
                     device_names, broadcom_wifi, detection_gaps, provenance,
                     framebuffers, native_device_ids, field_reports, macos_window,
                     card_readers, third_party, usb_mapping, acpi_tables,
-                    frozen_names, frozen_build, workflow_flags,
+                    window_stays_open, frozen_names, frozen_build, workflow_flags,
                     runner_independence, tables_match_sources):
         print(f'\n{section.__name__}')
         section()

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -919,5 +919,39 @@ def main():
     return 0
 
 
+def hold():
+    """Keep the window open when there is nobody else keeping it open.
+
+    A frozen build started from a file manager gets a console of its own, and
+    that console dies with the process - taking the summary, the warnings and
+    the path to the EFI with it. Somebody who double-clicked the executable sees
+    a window flash and nothing else.
+
+    Only there: from a shell the window outlives the program, and a run with
+    --answers has nobody to press the key."""
+    if not getattr(sys, 'frozen', False) or SCRIPTING:
+        return
+    try:
+        if not sys.stdin.isatty():
+            return
+        input('\n  Press enter to close.')
+    except (EOFError, OSError, KeyboardInterrupt):
+        pass
+
+
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        code = main()
+    except SystemExit as exc:
+        # a message rather than a number is how the tools refuse; printing it
+        # before the pause is the whole point of pausing
+        if isinstance(exc.code, str):
+            print(exc.code)
+            code = 1
+        else:
+            code = exc.code or 0
+    except KeyboardInterrupt:
+        print('\n  stopped')
+        code = 130
+    hold()
+    sys.exit(code)


### PR DESCRIPTION
Double-clicking the executable gets a console of its own, and that console dies
with the process - so the build summary, the warnings and the path to the EFI go
with it. A window flashes and that is all anybody sees.

The frozen build now waits for a key before exiting. Three conditions, each of
which matters:

* **only when frozen** - from a clone the shell owns the window and outlives the
  program;
* **only on a terminal** - a piped or redirected run has nobody to press
  anything, and hanging there would be worse than closing;
* **never under `--answers`** - that is CI, which has neither.

A refusal is printed before the pause rather than swallowed by it, since being
able to read the reason is the whole point. `Ctrl+C` is caught too, so it says
`stopped` instead of a traceback, and the exit code stays what it was.

Verified in a real frozen build here: the prompt appears on a pty and the
process is still alive when it does, and a frozen run with piped stdin does not
hang.