### PR TITLE
Read which bus the trackpad is on

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -179,6 +179,20 @@ jobs:
           python3 tools/thirdparty.py
           python3 tools/thirdparty.py --machine tools/fixtures/thinkpad-e570.json
 
+      - name: A trackpad on SMBus is told apart from one on PS/2
+        run: |
+          python3 - <<'CHECK'
+          import sys; sys.path.insert(0, 'tools')
+          import detect, summary
+          base, _ = detect.read_report('tools/fixtures/thinkpad-e570.json')
+          row = lambda hw: {r['part']: r for r in summary.rows(hw)}['Trackpad']
+          assert 'PS/2' in row(base)['detail'], row(base)
+          smbus = dict(base, device_names={**base['device_names'],
+                                           '8086:9d23': 'Synaptics SMBus Driver'})
+          assert 'VoodooRMI.kext' in row(smbus)['detail'], row(smbus)
+          print('SMBus and PS/2 are told apart')
+          CHECK
+
       - name: The card reader has three answers, not one
         run: |
           python3 - <<'CHECK'

--- a/tools/README.md
+++ b/tools/README.md
@@ -723,8 +723,17 @@ are PS2! You will want to grab VoodooPS2 even if you have an I2C, USB, or SMBus
 trackpad"* - and the profiles here already decide that per machine, so the line
 is repeated as a warning rather than acted on.
 
+**An SMBus trackpad can be told apart after all.** Windows names the SMBus
+controller after whatever bound to it, so a Synaptics or ELAN trackpad on that
+bus makes the device come back as `Synaptics SMBus Driver` rather than
+`Intel(R) SMBus Controller`. That is the machine saying which bus its trackpad
+is on, and it outranks the PS/2 controller also being there - on these laptops
+both are, and only one is carrying the pad. The kext `data/input.toml` quotes for
+that vendor is then offered, not added silently: a Windows driver name is good
+enough to ask on and not good enough to decide with.
+
 `NEXT-STEPS.txt` names the per-family plugins in the same release, the two SMBus
-paths for when it is not I2C at all, and the fact that some trackpads need an
+paths for when neither signal is there, and the fact that some trackpads need an
 SSDT first - which is machine-specific and not something this can write.
 
 ## Intel graphics framebuffer

--- a/tools/build.py
+++ b/tools/build.py
@@ -266,7 +266,12 @@ def main(argv=None):
             # made for the machine wins and the generic one is turned off, out
             # loud, because that is a decision and not a merge.
             for old_entry in config['ACPI']['Add']:
-                if acpi_tool.same_purpose(old_entry['Path'], entry['Path']):
+                if old_entry['Path'] == entry['Path']:
+                    # the same name is a replacement, not a conflict: the file in
+                    # the EFI is overwritten and the entry is rewritten below
+                    warn(f'{entry["Path"]} replaced by the one built for this '
+                         f'machine')
+                elif acpi_tool.same_purpose(old_entry['Path'], entry['Path']):
                     if old_entry.get('Enabled'):
                         warn(f'{old_entry["Path"]} disabled: {entry["Path"]} is '
                              f'built for this machine and does the same job')

--- a/tools/inputdev.py
+++ b/tools/inputdev.py
@@ -72,6 +72,32 @@ def entries(pci_ids, ps2_present, acpi_ids=None):
     return lines, kexts
 
 
+# Windows names the SMBus controller after whatever bound to it. A trackpad on
+# SMBus puts its vendor's driver there, so "Synaptics SMBus Driver" on the SMBus
+# device is the machine saying which bus its trackpad is on - the one thing that
+# could not be worked out before.
+SMBUS_VENDORS = {'synaptics': 'smbus-synaptics', 'elan': 'smbus-elan'}
+
+
+def smbus_trackpad(device_names):
+    """(bus, id, name) for an SMBus device a trackpad vendor has claimed."""
+    for device_id, name in sorted((device_names or {}).items()):
+        low = (name or '').lower()
+        if 'smbus' not in low:
+            continue
+        for vendor, bus in SMBUS_VENDORS.items():
+            if vendor in low:
+                return bus, device_id, name
+    return None, None, None
+
+
+def smbus_rule(bus):
+    for rule in load()['rule']:
+        if rule['bus'] == bus:
+            return rule
+    return None
+
+
 def smbus_notes():
     """The other two paths, for a machine with no I2C controller.
 

--- a/tools/provenance.py
+++ b/tools/provenance.py
@@ -127,8 +127,8 @@ def catalogue():
              tool='hand written',
              count=f'{rows_in("data/input.toml", "rule")} rules',
              covers='I2C, Synaptics SMBus, ELAN SMBus, and the PS/2 keyboard rule',
-             gap='Nothing readable says which bus a trackpad is on, so only the '
-                 'I2C case is acted on and the rest are named in the notes.'),
+             gap='I2C is read from the controller ids and SMBus from what '
+                 'Windows named the bus; a Linux or macOS report has neither.'),
         dict(area='macOS releases', kind=DERIVED, file='data/macos.toml',
              source="the repository's own patch comments, cross-checked",
              tool='tools/coverage.py --names',

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -911,6 +911,40 @@ def card_readers():
           other['verdict'] == summary.UNKNOWN, other)
 
 
+def smbus_trackpad():
+    """The machine names its own SMBus controller, which says which bus it is on.
+
+    A Synaptics or ELAN trackpad on SMBus puts its vendor's driver on the SMBus
+    device, and Windows reports the device under that name. Until this, nothing
+    read here could tell an SMBus trackpad from a PS/2 one, so both kexts were
+    only ever named in the notes."""
+    import inputdev
+    import summary
+    real = {'8086:9d23': 'Synaptics SMBus Driver'}
+    check('a vendor on the SMBus is read as the trackpad being there',
+          inputdev.smbus_trackpad(real)[0] == 'smbus-synaptics',
+          inputdev.smbus_trackpad(real))
+    check('ELAN too',
+          inputdev.smbus_trackpad({'8086:9d23': 'ELAN SMBus Device'})[0] == 'smbus-elan')
+    check('an SMBus controller nobody claimed says nothing',
+          inputdev.smbus_trackpad({'8086:9d23': 'Intel(R) SMBus - 9D23'})[0] is None)
+    check('nor does a Synaptics device that is not on the SMBus',
+          inputdev.smbus_trackpad({'8086:9d60': 'Synaptics Pointing Device'})[0] is None)
+    check('and the rule it points at is the quoted one',
+          inputdev.smbus_rule('smbus-synaptics')['kexts'] == ['VoodooRMI.kext'])
+
+    base, _ = detect.read_report('tools/fixtures/thinkpad-e570.json')
+    ps2_only = {r['part']: r for r in summary.rows(base)}['Trackpad']
+    check('without it the row still says PS/2', 'PS/2' in ps2_only['detail'], ps2_only)
+    on_smbus = dict(base, device_names={**base['device_names'], **real})
+    row = {r['part']: r for r in summary.rows(on_smbus)}['Trackpad']
+    check('with it the row names the kext instead',
+          'VoodooRMI.kext' in row['detail'], row)
+    # both controllers are present on these laptops; only one carries the pad
+    check('and the PS/2 controller being there too does not win',
+          'PS/2' not in row['detail'], row)
+
+
 def macos_window():
     """Where each part bounds macOS, and what the intersection of those is."""
     import summary
@@ -1039,7 +1073,7 @@ if __name__ == '__main__':
                     trackpad, framebuffer, boot_args, other_machine,
                     undecodable_output, scripted_answers, hardware_summary,
                     device_names, broadcom_wifi, detection_gaps, provenance,
-                    framebuffers, native_device_ids, field_reports, macos_window,
+                    framebuffers, native_device_ids, field_reports, smbus_trackpad, macos_window,
                     card_readers, third_party, usb_mapping, acpi_tables,
                     window_stays_open, frozen_names, frozen_build, workflow_flags,
                     runner_independence, tables_match_sources):

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -754,9 +754,27 @@ def main():
         if aside:
             print(f'      {DIM}ignored: {", ".join(aside)}  (remote desktop input, '
                   f'not this machine\'s){RESET}')
+        bus, smbus_id, smbus_name = inputdev.smbus_trackpad(hw.get('device_names'))
+        if bus:
+            rule = inputdev.smbus_rule(bus)
+            print(f'      {GREEN}{smbus_name}  [{smbus_id}]{RESET}')
+            print(f'      {DIM}Windows named the SMBus controller after the driver '
+                  f'bound to it, which\n      is this machine saying the trackpad is '
+                  f'on SMBus and not PS/2.{RESET}')
+            print(f'      {DIM}"{rule["quote"]}"{RESET}')
+            if ask(0, 0, f'Add {", ".join(rule["kexts"])} for it?',
+                   [('yes', f'Yes, add {", ".join(rule["kexts"])}'),
+                    ('no', 'No, VoodooPS2 alone')]) == 'yes':
+                for bundle in rule['kexts']:
+                    entry = {'Arch': 'x86_64', 'BundlePath': bundle,
+                             'Comment': rule['label'], 'Enabled': True,
+                             'ExecutablePath': '', 'MinKernel':
+                                 rule.get('min_kernel', ''), 'MaxKernel': '',
+                             'PlistPath': 'Contents/Info.plist'}
+                    input_kexts.append(entry)
         if input_lines:
             print('\n'.join(input_lines))
-        elif pointing:
+        elif pointing and not bus:
             print(f'      {DIM}no I2C controller here; if the trackpad turns out to be '
                   f'on SMBus, NEXT-STEPS.txt names the two kexts for that{RESET}')
         # the follow-up is written either way: a PS/2 laptop is the one most

--- a/tools/summary.py
+++ b/tools/summary.py
@@ -205,6 +205,14 @@ def input_row(hw):
     name = pointing[0]['name'] if pointing else ('I2C trackpad' if i2c else 'not readable')
     if i2c:
         return row('Trackpad', name, SUPPORTED, f'VoodooI2C  [{", ".join(i2c)}]')
+    # the machine names its own SMBus controller after whatever drives the
+    # trackpad, which outranks the PS/2 controller also being there: on these
+    # laptops both are, and only one of them is carrying the trackpad
+    bus, smbus_id, _ = inputdev.smbus_trackpad(hw.get('device_names'))
+    if bus:
+        rule = inputdev.smbus_rule(bus)
+        return row('Trackpad', name, SUPPORTED,
+                   f'{", ".join(rule["kexts"])} for {rule["label"]}  [{smbus_id}]')
     if hw.get('ps2'):
         return row('Trackpad', name, SUPPORTED,
                    'on PS/2; VoodooPS2 is in the laptop profile')


### PR DESCRIPTION
Two things from your last build, one a bug of mine and one a finding in your
report.

## The warning was nonsense when the names matched

```
warning  SSDT-XOSI.aml disabled: SSDT-XOSI.aml is built for this machine and does the same job
```

Same file on both sides. What actually happened is a replacement - the entry is
rewritten and the AML overwritten - not a disable, and nothing is left off. Same
name now says `replaced by the one built for this machine`; a different name
doing the same job still says `disabled`, because that one really is.

## Your report says which bus your trackpad is on

```
"8086:9d23": "Synaptics SMBus Driver"
```

`8086:9d23` is the SMBus controller, and Windows named it after the driver that
bound to it. That is this machine saying its trackpad is on SMBus - the one
thing this could not work out, and the reason both SMBus kexts have only ever
been named in the notes.

So it is read now. A Synaptics or ELAN name on an SMBus device selects the rule
`data/input.toml` already quotes, and the kext it names is **offered**:

```
Trackpad and keyboard
  Synaptics Pointing Device  (pointing device, ACPI\LEN2043 on the PS/2 controller)
      Synaptics SMBus Driver  [8086:9d23]
      Windows named the SMBus controller after the driver bound to it, which
      is this machine saying the trackpad is on SMBus and not PS/2.
      "For systems with Synaptics SMBus trackpads. Requires macOS 10.11 or newer..."

Add VoodooRMI.kext for it?
```

Offered, not added: the evidence is a Windows driver name, which is good enough
to ask on and not good enough to decide with. The summary row changes too, and
the "if it turns out to be on SMBus" note stops printing on machines where it no
longer turns out to be anything.

It outranks the PS/2 controller being present, because on these laptops both
are and only one is carrying the pad - asserted, along with the cases that must
stay silent: an unclaimed SMBus controller, and a Synaptics device that is not
on the SMBus.

**For your E570 this probably matters.** The build you just made has VoodooPS2
alone. If the trackpad is limited or does not gesture, rebuild and say yes.