### PR TITLE
Follow the install order the project gives

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -193,6 +193,34 @@ jobs:
           print('SMBus and PS/2 are told apart')
           CHECK
 
+      - name: Choosing SMBus follows the project's own install order
+        run: |
+          E570='--machine tools/fixtures/thinkpad-e570.json'
+          python3 - <<'MAKE'
+          import json
+          d = json.load(open('tools/fixtures/thinkpad-e570.json'))
+          d['device_names']['8086:9d23'] = 'Synaptics SMBus Driver'
+          json.dump(d, open('/tmp/smbus.json', 'w'))
+          MAKE
+          python3 tools/setup.py --machine /tmp/smbus.json --answers 1,1,1,1 \
+            --out /tmp/smbus/EFI
+          python3 - <<'CHECK'
+          import plistlib
+          d = plistlib.load(open('/tmp/smbus/EFI/OC/config.plist', 'rb'))
+          by = {k['BundlePath']: k for k in d['Kernel']['Add']}
+          for want in ('VoodooRMI.kext',
+                       'VoodooRMI.kext/Contents/PlugIns/VoodooInput.kext',
+                       'VoodooSMBus.kext',
+                       'VoodooRMI.kext/Contents/PlugIns/RMISMBus.kext'):
+              assert by[want]['Enabled'], want
+          off = 'VoodooPS2Controller.kext/Contents/PlugIns/VoodooInput.kext'
+          assert by[off]['Enabled'] is False, 'two VoodooInput kexts would load'
+          for keep in ('VoodooPS2Controller.kext',
+                       'VoodooPS2Controller.kext/Contents/PlugIns/VoodooPS2Trackpad.kext'):
+              assert by[keep]['Enabled'], keep
+          print('the SMBus set is complete and VoodooInput is not doubled')
+          CHECK
+
       - name: The card reader has three answers, not one
         run: |
           python3 - <<'CHECK'

--- a/data/input.toml
+++ b/data/input.toml
@@ -15,11 +15,25 @@ kexts = ["VoodooI2C.kext", "VoodooI2CHID.kext"]
 quote = "Attaches to I2C controllers to allow plugins to talk to I2C trackpads. Must be paired with one or more plugins"
 note = "VoodooI2CHID covers I2C-HID devices, which is most of them. ELAN, Synaptics and FTE trackpads have their own plugin in the same release."
 
+# Saying yes to this is not "add one kext". VoodooRMI's own Installation
+# section gives an ordered set and one plugin that has to come out: two
+# VoodooInput kexts loaded at once is the failure it is warning about. The order
+# is the project's, kept as written.
 [[rule]]
 bus = "smbus-synaptics"
 label = "Synaptics SMBus trackpad"
-kexts = ["VoodooRMI.kext"]
+source = "VoodooSMBus/VoodooRMI README, Compatibility and Installation"
+kexts = [
+    "VoodooRMI.kext",
+    "VoodooRMI.kext/Contents/PlugIns/VoodooInput.kext",
+    "VoodooSMBus.kext",
+    "VoodooRMI.kext/Contents/PlugIns/RMISMBus.kext",
+]
+disable = ["VoodooPS2Controller.kext/Contents/PlugIns/VoodooInput.kext"]
+needs = "VoodooPS2 2.3.6 or newer, which the profiles already carry"
 quote = "For systems with Synaptics SMBus trackpads. Requires macOS 10.11 or newer for MT2 functions. Depends on Acidanthera's VoodooPS2"
+windows_check = "Check under Device Manager for a Synaptics SMBus device"
+macos_check = "Look in IORegistryExplorer under ApplePS2SynapticsTrackpad, and look for the value Intertouch Support=True"
 
 [[rule]]
 bus = "smbus-elan"

--- a/tools/README.md
+++ b/tools/README.md
@@ -728,9 +728,22 @@ controller after whatever bound to it, so a Synaptics or ELAN trackpad on that
 bus makes the device come back as `Synaptics SMBus Driver` rather than
 `Intel(R) SMBus Controller`. That is the machine saying which bus its trackpad
 is on, and it outranks the PS/2 controller also being there - on these laptops
-both are, and only one is carrying the pad. The kext `data/input.toml` quotes for
-that vendor is then offered, not added silently: a Windows driver name is good
-enough to ask on and not good enough to decide with.
+both are, and only one is carrying the pad. The kexts `data/input.toml` quotes for
+that vendor are then offered, not added silently, for three reasons that are all
+in the project's own README:
+
+* The Windows signal is upstream's own test - *"Check under Device Manager for a
+  Synaptics SMBus device"* - but upstream also gives a **macOS** confirmation,
+  `Intertouch Support=True` in IORegistry, and that one cannot be seen from
+  Windows. So the evidence is the right evidence and it is not the last word.
+* A Synaptics pad works over SMBus *or* I2C, *"though not both"*, and the PS/2
+  path is there as a fallback on the same machine. Both show up in Windows.
+* Saying yes is not "add one kext". The Installation section gives four in a
+  fixed order and requires **disabling** the profile's
+  `VoodooPS2Controller.kext/Contents/PlugIns/VoodooInput.kext`, because two
+  VoodooInput kexts must not load at once. That set is what goes in, in that
+  order, and the disabled one stays in the config turned off so putting it back
+  is one edit.
 
 `NEXT-STEPS.txt` names the per-family plugins in the same release, the two SMBus
 paths for when neither signal is there, and the fact that some trackpads need an

--- a/tools/build.py
+++ b/tools/build.py
@@ -144,6 +144,8 @@ def main(argv=None):
     ap.add_argument('--device-props', help='JSON of DeviceProperties to merge in')
     ap.add_argument('--acpi', metavar='DIR',
                     help='a SSDTTime Results folder: its SSDTs and patches go in')
+    ap.add_argument('--disable-kexts',
+                    help='comma-separated BundlePaths to turn off but leave in')
     ap.add_argument('--drop-kexts', help='bundle names to disable, comma separated')
     a = ap.parse_args(argv)
 
@@ -293,6 +295,17 @@ def main(argv=None):
         if add or fresh:
             print(f'  ACPI         {len(add)} SSDTs, {len(fresh)} patches from '
                   f'{a.acpi}')
+
+    if a.disable_kexts:
+        # off, not out: a kext another one replaces has to stay in the config so
+        # that turning it back on is one edit, and so that what was decided is
+        # visible rather than absent
+        names = {x.strip() for x in a.disable_kexts.split(',') if x.strip()}
+        for entry in config['Kernel']['Add']:
+            if entry['BundlePath'] in names and entry.get('Enabled'):
+                entry['Enabled'] = False
+                warn(f'{entry["BundlePath"]} disabled: the kext replacing it says '
+                     f'it must not load too')
 
     if a.drop_kexts:
         drop = {x.strip() for x in a.drop_kexts.split(',') if x.strip()}

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -930,8 +930,37 @@ def smbus_trackpad():
           inputdev.smbus_trackpad({'8086:9d23': 'Intel(R) SMBus - 9D23'})[0] is None)
     check('nor does a Synaptics device that is not on the SMBus',
           inputdev.smbus_trackpad({'8086:9d60': 'Synaptics Pointing Device'})[0] is None)
-    check('and the rule it points at is the quoted one',
-          inputdev.smbus_rule('smbus-synaptics')['kexts'] == ['VoodooRMI.kext'])
+    # saying yes is not "add one kext": the project gives an ordered set and one
+    # plugin that has to come out, and two VoodooInput kexts at once is the
+    # failure it is warning about
+    rule = inputdev.smbus_rule('smbus-synaptics')
+    check('the rule carries the whole ordered set',
+          rule['kexts'] == ['VoodooRMI.kext',
+                            'VoodooRMI.kext/Contents/PlugIns/VoodooInput.kext',
+                            'VoodooSMBus.kext',
+                            'VoodooRMI.kext/Contents/PlugIns/RMISMBus.kext'],
+          rule['kexts'])
+    check("and what the profile's has to stop doing",
+          rule['disable'] == ['VoodooPS2Controller.kext/Contents/PlugIns/'
+                              'VoodooInput.kext'], rule.get('disable'))
+    check('every plugin it names is in the vendored kext',
+          all((Path('EFI/OC/Kexts') / k).exists() for k in rule['kexts']),
+          [k for k in rule['kexts'] if not (Path('EFI/OC/Kexts') / k).exists()])
+    check('and the check to run in macOS afterwards is quoted',
+          'Intertouch Support' in rule['macos_check'])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / 'EFI'
+        r = run([sys.executable, 'tools/build.py', '--platform', 'laptop',
+                 '--cpu', 'kaby-lake', '--disable-kexts', rule['disable'][0],
+                 '--out', str(out)])
+        check('a build can turn one off without taking it out', r.returncode == 0)
+        if r.returncode == 0:
+            cfg = ocgen.load_plist(out / 'OC' / 'config.plist')
+            by = {k['BundlePath']: k for k in cfg['Kernel']['Add']}
+            check('it is off', by[rule['disable'][0]]['Enabled'] is False)
+            check('and still there, so turning it back on is one edit',
+                  rule['disable'][0] in by)
 
     base, _ = detect.read_report('tools/fixtures/thinkpad-e570.json')
     ps2_only = {r['part']: r for r in summary.rows(base)}['Trackpad']

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -648,6 +648,7 @@ def main():
                   f'there with\n      detect.py --report machine.json --acpi ACPI/'
                   f'{RESET}')
 
+    smbus_disable = []
     usb_implies = None
     queued = []
     if interactive and not a.usb_map and usbmap.available() and usbmap.runnable_here():
@@ -762,8 +763,17 @@ def main():
                   f'bound to it, which\n      is this machine saying the trackpad is '
                   f'on SMBus and not PS/2.{RESET}')
             print(f'      {DIM}"{rule["quote"]}"{RESET}')
-            if ask(0, 0, f'Add {", ".join(rule["kexts"])} for it?',
-                   [('yes', f'Yes, add {", ".join(rule["kexts"])}'),
+            print(f'      {DIM}{len(rule["kexts"])} kexts in the order the project '
+                  f'gives, and {len(rule.get("disable", []))} of the profile\'s '
+                  f'turned off:\n'
+                  + '\n'.join(f'        + {k}' for k in rule['kexts'])
+                  + ''.join(f'\n        - {k}' for k in rule.get('disable', []))
+                  + RESET)
+            if rule.get('macos_check'):
+                print(f'      {DIM}Confirm it in macOS afterwards: '
+                      f'"{rule["macos_check"]}"{RESET}')
+            if ask(0, 0, 'Set the trackpad up for SMBus?',
+                   [('yes', 'Yes, as the project says'),
                     ('no', 'No, VoodooPS2 alone')]) == 'yes':
                 for bundle in rule['kexts']:
                     entry = {'Arch': 'x86_64', 'BundlePath': bundle,
@@ -772,6 +782,7 @@ def main():
                                  rule.get('min_kernel', ''), 'MaxKernel': '',
                              'PlistPath': 'Contents/Info.plist'}
                     input_kexts.append(entry)
+                smbus_disable = list(rule.get('disable', []))
         if input_lines:
             print('\n'.join(input_lines))
         elif pointing and not bus:
@@ -908,6 +919,8 @@ def main():
         cmd += ['--oem', row['oem']]
     if acpi_results:
         cmd += ['--acpi', acpi_results]
+    if smbus_disable:
+        cmd += ['--disable-kexts', ','.join(smbus_disable)]
 
     print(f'\n{BOLD}Building{RESET}')
     print(f'  {DIM}build {" ".join(cmd)}{RESET}\n')


### PR DESCRIPTION
You asked why the trackpad kext is offered rather than added. Going to the
source to answer it properly turned up a bug in what I shipped yesterday.

## What I got wrong

VoodooRMI's Installation section is specific:

> * Enabled: VoodooPS2Controller, VoodooPS2Mouse, VoodooPS2Keyboard, VoodooPS2Trackpad
> * Disabled: VoodooPS2Controller.kext/Contents/PlugIns/VoodooInput.kext
>
> For OpenCore users, make sure to add the below kexts in the order they're listed:
> VoodooRMI.kext, VoodooRMI.kext/Contents/PlugIns/VoodooInput.kext,
> VoodooSMBus.kext, VoodooRMI.kext/Contents/PlugIns/RMISMBus.kext

#89 added `VoodooRMI.kext` and nothing else, and left the profile's
`VoodooInput.kext` enabled. Two VoodooInput kexts loading at once is the thing
that instruction exists to prevent, so saying yes could have left the trackpad
worse than leaving it alone.

Now the whole set goes in, in that order, and the profile's plugin is turned
**off rather than removed** - it stays in the config so putting it back is one
edit, and so the decision is visible instead of absent. `build.py --disable-kexts`
is how, and it says what it did.

## And the answer to the question

Three reasons, all from the project's own README rather than from caution:

1. **The Windows signal is upstream's own test** - *"Check under Device Manager
   for a Synaptics SMBus device"* - but the README also gives a **macOS**
   confirmation, `Intertouch Support=True` in IORegistry, which cannot be seen
   from Windows. Right evidence, not the last word. The builder now prints that
   check so it can be run afterwards.
2. **A Synaptics pad works over SMBus or I2C, "though not both"**, and PS/2 is
   the fallback on the same machine. Your report shows both, which is normal and
   is why a detector cannot simply pick.
3. **Saying yes changes four kexts and disables a fifth.** That is a decision
   worth a question, and it is the reason the question exists.

Asserted: the ordered set, the disabled plugin, that every plugin named is
actually inside the vendored kext, and that a disabled entry stays in the config.