### PR TITLE
Check the load order against what the kexts declare

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -193,6 +193,9 @@ jobs:
           print('SMBus and PS/2 are told apart')
           CHECK
 
+      - name: Every kext is listed after the ones it needs
+        run: python3 tools/kextorder.py
+
       - name: Choosing SMBus follows the project's own install order
         run: |
           E570='--machine tools/fixtures/thinkpad-e570.json'

--- a/tools/README.md
+++ b/tools/README.md
@@ -319,6 +319,41 @@ The existence of several was learnt from `lzhoang2801/OpCore-Simplify`, whose
 `pci_data.py` covers roles this repository does not. None of its data is copied;
 the ids come from the kexts.
 
+## Kext load order
+
+OpenCore loads kexts in the order they appear in `Kernel.Add`, and a dependency
+listed after the kext that needs it does not fail loudly - the dependent kext
+simply never loads, and whatever it was for does not work. The reference manual
+states the rule and says where to read the answer from:
+
+> The load order is based on the order in which the kexts appear in the array.
+> Hence, dependencies must appear before kexts that depend on them.
+>
+> To track the dependency order, inspect the `OSBundleLibraries` key in the
+> `Info.plist` file of the kext being added. Any kext included under the key is
+> a dependency that must appear before the kext being added.
+>
+> Kexts may have inner kexts (`Plugins`) included in the bundle. Such `Plugins`
+> must be added separately and follow the same global ordering rules as other
+> kexts.
+
+So `tools/kextorder.py` does exactly that: it reads `OSBundleLibraries` out of
+every vendored kext - 28 of 54 bundles declare one - resolves each identifier to
+the bundle that provides it, and checks that it appears earlier in the list. A
+plugin is a bundle path of its own, because that is how OpenCore refers to it.
+
+    python3 tools/kextorder.py                    # every published config
+    python3 tools/kextorder.py path/to/config.plist
+
+Every build runs the same check and warns; the 179 published configs are checked
+in CI. They all pass, and they passed before this existed - the order was right
+by hand. What was missing was anything that would notice if it stopped being.
+
+**It never reorders.** The order in a published config is somebody's decision,
+and rewriting it silently would hide a mistake rather than name it. A kext that
+is disabled counts as absent, because a kext that does not load cannot satisfy
+anything.
+
 ## Where the answers come from
 
     python3 tools/provenance.py            # every category and its source

--- a/tools/build.py
+++ b/tools/build.py
@@ -315,6 +315,17 @@ def main(argv=None):
         if before != len(config['Kernel']['Add']):
             print(f'  dropped      {", ".join(sorted(drop))}')
 
+    # OpenCore loads kexts in the order they appear, so a dependency listed
+    # after the kext that needs it does not fail loudly - the dependent one just
+    # does not load. Checked here rather than left to be discovered on the
+    # machine, and never reordered: the order in a published config is somebody's
+    # decision, and silently rewriting it would hide the mistake instead of
+    # naming it.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import kextorder
+    for bundle, needed, why in kextorder.check(config['Kernel']['Add']):
+        warn(f'load order: {bundle} needs {needed}, which {why}')
+
     serial = apply_identity(config, a.identity, warn)
 
     out = Path(a.out)

--- a/tools/kextorder.py
+++ b/tools/kextorder.py
@@ -1,0 +1,125 @@
+"""Check that every kext is listed after the ones it needs.
+
+This is not a rule anybody here invented. OpenCore's own reference manual says
+it, and says where to read the answer from:
+
+    "The load order is based on the order in which the kexts appear in the
+     array. Hence, dependencies must appear before kexts that depend on them."
+
+    "To track the dependency order, inspect the OSBundleLibraries key in the
+     Info.plist file of the kext being added. Any kext included under the key is
+     a dependency that must appear before the kext being added."
+
+    "Kexts may have inner kexts (Plugins) included in the bundle. Such Plugins
+     must be added separately and follow the same global ordering rules as other
+     kexts."
+
+So the graph is read out of the kexts, exactly as instructed, and nothing about
+which kext needs which is written down here. A config that fails this does not
+fail loudly at boot: the dependent kext simply does not load, and whatever it
+was for does not work.
+
+    python3 tools/kextorder.py                    # every published config
+    python3 tools/kextorder.py path/to/config.plist
+"""
+import argparse
+import os
+import plistlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ocgen
+
+KEXTS = Path('EFI/OC/Kexts')
+
+BOLD, DIM, GREEN, RED, RESET = '\033[1m', '\033[2m', '\033[32m', '\033[31m', '\033[0m'
+if os.environ.get('NO_COLOR') or not sys.stdout.isatty():
+    BOLD = DIM = GREEN = RED = RESET = ''
+
+
+def graph(root=KEXTS):
+    """{bundle path: {bundle paths it needs}} from the kexts themselves.
+
+    A plugin is a bundle path of its own - `VoodooRMI.kext/Contents/PlugIns/
+    RMISMBus.kext` - because that is how OpenCore refers to it and how the
+    manual says to treat it."""
+    root = Path(root)
+    ids, declared = {}, {}
+    for info in sorted(root.rglob('Contents/Info.plist')):
+        bundle = str(info.parent.parent.relative_to(root))
+        try:
+            with open(info, 'rb') as fh:
+                plist = plistlib.load(fh)
+        except (OSError, plistlib.InvalidFileException):
+            continue
+        ids[plist.get('CFBundleIdentifier', '')] = bundle
+        # the 64-bit list is separate in older bundles and means the same thing
+        declared[bundle] = set(plist.get('OSBundleLibraries') or {}) | set(
+            plist.get('OSBundleLibraries_x86_64') or {})
+    return {b: {ids[i] for i in want if i in ids} - {b}
+            for b, want in declared.items()}
+
+
+def check(entries, deps=None):
+    """[(bundle, needed, why)] for every enabled kext listed too early.
+
+    Only the enabled ones: a kext that is off does not load, so it cannot
+    satisfy anything and cannot be waiting on anything."""
+    deps = graph() if deps is None else deps
+    order = [e['BundlePath'] for e in entries if e.get('Enabled')]
+    where = {}
+    for i, bundle in enumerate(order):
+        where.setdefault(bundle, i)
+    problems = []
+    for i, bundle in enumerate(order):
+        for needed in sorted(deps.get(bundle, ())):
+            if needed not in where:
+                problems.append((bundle, needed, 'is not in the config'))
+            elif where[needed] > i:
+                problems.append((bundle, needed, f'is listed after it, at '
+                                                 f'{where[needed] + 1} not before '
+                                                 f'{i + 1}'))
+    return problems
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('config', nargs='?', help='a config.plist to check')
+    a = ap.parse_args(argv)
+
+    deps = graph()
+    if a.config:
+        cfg = ocgen.load_plist(Path(a.config))
+        problems = check(cfg['Kernel']['Add'], deps)
+        for bundle, needed, why in problems:
+            print(f'  {RED}{bundle}{RESET} needs {needed}, which {why}')
+        print(f'  {"no ordering problems" if not problems else str(len(problems)) + " problems"}'
+              f' in {a.config}')
+        return 1 if problems else 0
+
+    import verify
+    sample = ocgen.load_plist(ocgen.vendored_sample())
+    profiles = Path('profiles')
+    entries = ocgen.read_toml(profiles / 'catalogue.toml')['config']
+    seen = {}
+    for e in entries:
+        row = verify._row(e)
+        cfg = ocgen.assemble(sample, ocgen.layer_chain(row, profiles),
+                             ocgen.build_params(row))
+        for bundle, needed, why in check(cfg['Kernel']['Add'], deps):
+            seen.setdefault((bundle, needed, why), []).append(e['name'])
+    linked = sum(1 for v in deps.values() if v)
+    print(f'{BOLD}Kext load order{RESET}  {DIM}{linked} of {len(deps)} bundles '
+          f'declare a dependency{RESET}\n')
+    for (bundle, needed, why), names in sorted(seen.items(), key=lambda x: -len(x[1])):
+        print(f'  {RED}{len(names):3d}{RESET}  {bundle} needs {needed}, which {why}')
+        print(f'       e.g. {names[0]}')
+    if not seen:
+        print(f'  {GREEN}{len(entries)} published configs, every dependency listed '
+              f'before the kext that needs it{RESET}')
+    return 1 if seen else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/provenance.py
+++ b/tools/provenance.py
@@ -154,6 +154,14 @@ def catalogue():
              covers='processors whose iGPU behaves differently from its generation',
              gap='One person, one machine each. It outranks the generation rule '
                  'because it is more specific, not because it is stronger.'),
+        dict(area='Kext load order', kind=DERIVED, file='EFI/OC/Kexts/',
+             source="OSBundleLibraries in each kext, as OpenCore's manual says",
+             tool='tools/kextorder.py',
+             count='28 of 54 bundles declare a dependency',
+             covers='that every kext is listed after the ones it needs, in every '
+                    'published config and every build',
+             gap='Only kexts vendored here. It reports and never reorders: the '
+                 'order is a decision, and rewriting it would hide the mistake.'),
         dict(area='Third-party licences', kind=DERIVED, file='vendor/licences.toml',
              source="each project's own LICENSE file, read from GitHub",
              tool='tools/thirdparty.py --refresh',

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -911,6 +911,56 @@ def card_readers():
           other['verdict'] == summary.UNKNOWN, other)
 
 
+def load_order():
+    """OpenCore loads kexts in list order, so a dependency listed late is inert.
+
+    Not a rule anybody here invented: the reference manual states it and says to
+    read OSBundleLibraries for the answer, which is where the graph comes from.
+    A config that gets this wrong does not fail loudly - the dependent kext just
+    never loads, and whatever it was for does not work."""
+    import kextorder
+    deps = kextorder.graph()
+    check('the graph is read from the kexts, not written down',
+          deps.get('WhateverGreen.kext') == {'Lilu.kext'}, deps.get('WhateverGreen.kext'))
+    check('a plugin is a bundle path of its own, as the manual says',
+          'VoodooRMI.kext' in deps.get(
+              'VoodooRMI.kext/Contents/PlugIns/RMISMBus.kext', set()),
+          deps.get('VoodooRMI.kext/Contents/PlugIns/RMISMBus.kext'))
+    check('and a kext with no libraries needs nothing',
+          not deps.get('Lilu.kext'), deps.get('Lilu.kext'))
+
+    wrong = [{'BundlePath': 'WhateverGreen.kext', 'Enabled': True},
+             {'BundlePath': 'Lilu.kext', 'Enabled': True}]
+    found = kextorder.check(wrong, deps)
+    check('the wrong way round is caught', len(found) == 1 and
+          found[0][:2] == ('WhateverGreen.kext', 'Lilu.kext'), found)
+    right = list(reversed(wrong))
+    check('and the right way round is not', not kextorder.check(right, deps))
+    off = [{'BundlePath': 'WhateverGreen.kext', 'Enabled': True},
+           {'BundlePath': 'Lilu.kext', 'Enabled': False}]
+    check('a dependency that is present but disabled counts as absent',
+          kextorder.check(off, deps)[0][2] == 'is not in the config',
+          kextorder.check(off, deps))
+
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()) as printed:
+        rc = kextorder.main([])
+    check('every published config is in order', rc == 0, printed.getvalue())
+
+    # and a build that adds kexts keeps it that way
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / 'EFI'
+        r = run([sys.executable, 'tools/setup.py',
+                 '--machine', 'tools/fixtures/thinkpad-e570.json',
+                 '--answers', '1,1,1', '--out', str(out)])
+        check('a build with kexts added succeeds', r.returncode == 0)
+        if r.returncode == 0:
+            cfg = ocgen.load_plist(out / 'OC' / 'config.plist')
+            problems = kextorder.check(cfg['Kernel']['Add'], deps)
+            check('and what was added is still in order', not problems, problems)
+
+
 def smbus_trackpad():
     """The machine names its own SMBus controller, which says which bus it is on.
 
@@ -1102,7 +1152,7 @@ if __name__ == '__main__':
                     trackpad, framebuffer, boot_args, other_machine,
                     undecodable_output, scripted_answers, hardware_summary,
                     device_names, broadcom_wifi, detection_gaps, provenance,
-                    framebuffers, native_device_ids, field_reports, smbus_trackpad, macos_window,
+                    framebuffers, native_device_ids, field_reports, load_order, smbus_trackpad, macos_window,
                     card_readers, third_party, usb_mapping, acpi_tables,
                     window_stays_open, frozen_names, frozen_build, workflow_flags,
                     runner_independence, tables_match_sources):


### PR DESCRIPTION
You asked what we order kexts by and where the rule comes from. The answer was:
nothing, and nowhere. The order was right, but by hand.

## The rule, and its source

OpenCore's own reference manual states it and says where to read the answer:

> The load order is based on the order in which the kexts appear in the array.
> Hence, dependencies must appear before kexts that depend on them.
>
> To track the dependency order, inspect the `OSBundleLibraries` key in the
> `Info.plist` file of the kext being added. Any kext included under the key is
> a dependency that must appear before the kext being added.
>
> Kexts may have inner kexts (`Plugins`) included in the bundle. Such `Plugins`
> must be added separately and follow the same global ordering rules as other
> kexts.

So `tools/kextorder.py` does exactly that - reads `OSBundleLibraries` out of
every vendored kext, resolves each identifier to the bundle that provides it,
and checks it appears earlier. 28 of 54 bundles declare one. Nothing about which
kext needs which is written down by hand; it is the same provenance rule as
`data/hardware.toml`.

## What it found

**Nothing.** All 179 published configs are correctly ordered, and so is every
build that adds kexts. That is the answer to your question: we were getting it
right, and there was nothing that would have noticed if we stopped.

Now every build runs the check and warns, and CI runs it across all 179.

## Two decisions in it

* **It never reorders.** The order in a published config is somebody's decision.
  Rewriting it silently would hide a mistake instead of naming it - and it would
  break byte-equality against the catalogue, which is the gate.
* **A disabled kext counts as absent.** A kext that does not load cannot satisfy
  anything, so `WhateverGreen` with `Lilu` present-but-off is reported the same
  as `Lilu` missing. That case is real now that #90 disables a plugin.

Worth knowing for the SMBus set from #90: `RMISMBus.kext` declares both
`VoodooRMI.kext` and `VoodooSMBus.kext`, and the order VoodooRMI's README gives
satisfies both. The instruction and the declaration agree, which is a good sign
for both.