### PR TITLE
One question, then the facts, then one question

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -245,7 +245,31 @@ device located - no fake needed"*, *"No patching or SSDT needed"*, *"Could not
 locate a valid bus device! Aborting"*. The choice stays the tool's; what goes
 away is a person pressing the same keys.
 
-The rest stay in the menus because they ask real questions - PNLF asks five,
+The flow is one question, then the facts, then one question about what is left:
+
+    Work out the SSDTs for this machine?
+       1) Yes
+       2) No, the profile's generic SSDTs will do
+
+           SSDT-EC          written
+           SSDT-PLUG        written
+           SSDT-AWAC        not needed on this machine
+           SSDT-HPET        needs a choice
+           4 written, 1 not needed, 1 waiting on a choice
+
+           8 more need an answer only you can give:
+             SSDT-HPET   IRQ conflicts, if there are any
+             SSDT-PNLF   laptop backlight; asks about the panel
+             ...
+
+    Open SSDTTime to work through those too?
+
+Three answers up front - automatic, menu, no - read as a puzzle to solve before
+anything has happened. This way the choice comes after the outcomes, and every
+patch the tool can do is named whether it ran or not, so nothing is invisible.
+
+"Written" means a file appeared, judged from the folder rather than from what
+the tool printed. The rest stay in the menus because they ask real questions - PNLF asks five,
 XOSI and USBX and DMAR one each - and answering those for somebody is what this
 must not do. The laptop profiles already carry a generic XOSI and PNLF, so that
 gap is smaller than it looks.

--- a/tools/acpi.py
+++ b/tools/acpi.py
@@ -166,7 +166,7 @@ def load(work):
     return module
 
 
-def run(work, tables=None, unattended=False):
+def run(work, tables=None, unattended=False, outcomes=None):
     """Drive the tool. Returns the Results folder it wrote into, or None.
 
     unattended runs the self-deciding patches and returns, instead of handing
@@ -180,6 +180,7 @@ def run(work, tables=None, unattended=False):
 
     work = prepare(work)
     here = Path.cwd()
+    outcomes = outcomes if outcomes is not None else []
     module = load(work)
     ssdt = module.SSDT()
     if tables:
@@ -200,8 +201,7 @@ def run(work, tables=None, unattended=False):
         if unattended:
             if not ssdt.dsdt:
                 return None, 'no ACPI tables were loaded, so there is nothing to read'
-            for name, outcome in automatic(ssdt):
-                print(f'      {name:16s} {outcome}')
+            outcomes.extend(automatic(ssdt, work / 'Results'))
             raise SystemExit(0)
         while True:
             ssdt.main()
@@ -295,6 +295,20 @@ AUTOMATIC = [
 ]
 
 
+# The ones never attempted unattended, and what they would ask about. Named so
+# that choosing the automatic run does not leave them invisible: somebody who
+# needs PNLF should be told it exists, not left to find out.
+ASKS = [
+    ('SSDT-PNLF', 'laptop backlight; asks about the panel'),
+    ('SSDT-XOSI', 'which Windows versions _OSI should answer to'),
+    ('SSDT-USBX', 'USB power properties'),
+    ('DMAR', 'reserved memory regions; asks which to drop'),
+    ('SSDT-USB-Reset', 'for USB port mapping, which is its own step'),
+    ('SSDT-Bridge', 'needs the device path of the bridge to create'),
+    ('SSDT-IMEI', 'asks which bridge to define'),
+]
+
+
 class _Unattended(Exception):
     """Raised when a patch asks something a person would have to answer."""
 
@@ -310,47 +324,57 @@ def _auto_grab(prompt=''):
     raise _Unattended(str(prompt).strip() or 'a question with no prompt')
 
 
-def automatic(ssdt):
-    """Run the self-deciding patches. Returns [(name, what happened)]."""
+def automatic(ssdt, results=None):
+    """Run the self-deciding patches. Returns [(name, outcome, detail)]."""
     import contextlib
     import io
+    results = Path(results) if results else None
     done = []
     original = ssdt.u.grab
+
+    def files():
+        return set(results.glob('*.aml')) if results and results.exists() else set()
+
     try:
         ssdt.u.grab = _auto_grab
         for method, name, what in AUTOMATIC:
             run = getattr(ssdt, method, None)
             if not run:
-                done.append((name, 'not in this version of the tool'))
+                done.append((name, NOT_NEEDED, 'not in this version of the tool'))
                 continue
+            before = files()
             printed = io.StringIO()
             try:
                 with contextlib.redirect_stdout(printed):
                     run()
-                done.append((name, _summarise(printed.getvalue(), what)))
+                done.append((name, *_outcome(printed.getvalue(), before, files())))
             except _Unattended as exc:
-                # not a failure: the patch found something that needs a choice.
+                # not a failure: the patch found something that needs an answer.
                 # fix_hpet does this the moment there is an IRQ conflict, which
-                # is the only time it has anything to do.
-                done.append((name, f'needs a choice, so it is in the menu: '
-                                   f'"{exc}"'))
+                # is the only time it has anything to do at all.
+                done.append((name, ASKED, str(exc)))
             except Exception as exc:                # noqa: BLE001
-                done.append((name, f'stopped: {exc!r}'))
+                done.append((name, 'stopped', repr(exc)))
     finally:
         ssdt.u.grab = original
     return done
 
+# Three outcomes, and they are the whole story: it wrote something, it looked
+# and there was nothing to write, or it wanted an answer. Anything else is the
+# tool falling over, which is reported as itself.
+WROTE, NOT_NEEDED, ASKED = 'written', 'not needed on this machine', 'needs a choice'
 
-def _summarise(output, what):
-    """One line from a screenful, preferring what the tool said it did."""
+
+def _outcome(output, before, after):
+    """What happened, judged by whether a file appeared rather than by the screen."""
+    fresh = after - before
+    if fresh:
+        return WROTE, ', '.join(sorted(p.name for p in fresh))
     for line in reversed(output.splitlines()):
-        line = line.strip()
-        if not line or line.startswith(('#', 'Press')):
-            continue
-        if 'Done' in line or '.aml' in line or 'no ' in line.lower():
-            return line
-    return what
-
+        line = line.strip().lstrip('->  ')
+        if line and not line.startswith(('#', 'Press')):
+            return NOT_NEEDED, line
+    return NOT_NEEDED, ''
 
 def collect(results):
     """(aml files, ACPI.Add entries, ACPI.Patch entries) from a Results folder.

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -742,11 +742,48 @@ def unattended_ssdts():
         ssdt.u.grab = acpi._auto_grab
         with contextlib.redirect_stdout(io.StringIO()):
             ssdt.dsdt = ssdt.load_dsdt(str(Path('tools/fixtures/acpi').resolve()))
-            outcomes = dict(acpi.automatic(ssdt))
+            outcomes = {n: o for n, o, _ in acpi.automatic(ssdt)}
         check('a patch that asks is reported, not answered',
-              'needs a choice' in outcomes.get('SSDT-HPET', ''), outcomes)
+              outcomes.get('SSDT-HPET') == acpi.ASKED, outcomes)
         check('and the ones that do not ask still ran',
-              'Done' in outcomes.get('SSDT-EC', ''), outcomes)
+              outcomes.get('SSDT-EC') in (acpi.WROTE, acpi.NOT_NEEDED), outcomes)
+
+
+def ssdt_flow():
+    """One question, then the facts, then one question about what is left.
+
+    Three answers up front read as a puzzle to solve before anything has
+    happened. The choice belongs after the outcomes, not before them."""
+    import acpi
+    src = Path('tools/setup.py').read_text()
+    check('there is one question to start with, not three',
+          "'Work out the SSDTs for this machine?'" in src)
+    check('and one about the rest, after the outcomes',
+          "'Open SSDTTime to work through those too?'" in src)
+    check('every patch never attempted is named',
+          len(acpi.ASKS) >= 6 and all(len(x) == 2 and all(x) for x in acpi.ASKS),
+          acpi.ASKS)
+    named = {n for n, _ in acpi.ASKS} | {n for _, n, _ in acpi.AUTOMATIC}
+    check('so nothing the tool can do is invisible', len(named) >= 12, sorted(named))
+
+    if not acpi.available():
+        return
+    import contextlib
+    import io
+    with tempfile.TemporaryDirectory() as tmp:
+        outcomes = []
+        with contextlib.redirect_stdout(io.StringIO()):
+            acpi.run(Path(tmp) / 'a', tables='tools/fixtures/acpi',
+                     unattended=True, outcomes=outcomes)
+        kinds = {o for _, o, _ in outcomes}
+        check('the outcomes are the three plain ones',
+              kinds <= {acpi.WROTE, acpi.NOT_NEEDED, acpi.ASKED}, kinds)
+        wrote = [n for n, o, _ in outcomes if o == acpi.WROTE]
+        check('and "written" means a file appeared', wrote, outcomes)
+        # the fixture's HPET conflicts, so exactly this is what the person sees
+        asked = [n for n, o, _ in outcomes if o == acpi.ASKED]
+        check('a patch that wants an answer is one of them', asked == ['SSDT-HPET'],
+              asked)
 
 
 def frozen_names():
@@ -1207,7 +1244,7 @@ if __name__ == '__main__':
                     device_names, broadcom_wifi, detection_gaps, provenance,
                     framebuffers, native_device_ids, field_reports, load_order,
                     smbus_trackpad, macos_window, card_readers, third_party,
-                    usb_mapping, acpi_tables, unattended_ssdts, window_stays_open,
+                    usb_mapping, acpi_tables, unattended_ssdts, ssdt_flow, window_stays_open,
                     frozen_names, frozen_build, workflow_flags,
                     runner_independence, tables_match_sources):
         print(f'\n{section.__name__}')

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -221,6 +221,58 @@ def check_tools():
     return 0
 
 
+def run_ssdts(a, where):
+    """Work out the SSDTs, in one pass a person can follow.
+
+    The automatic ones first, then a plain list of what happened, then one
+    question about the rest. Three answers up front - automatic, menu, no - read
+    as a puzzle to solve before anything has happened; this way the choice comes
+    after the facts."""
+    outcomes = []
+    got, complaint = acpi.run(Path(a.out).parent / 'acpi', a.acpi_tables,
+                              unattended=True, outcomes=outcomes)
+    if not got and not outcomes:
+        print(f'      {YELLOW}{complaint}{RESET}')
+        return None
+
+    for name, outcome, detail in outcomes:
+        colour = GREEN if outcome == acpi.WROTE else DIM
+        print(f'      {colour}{name:16s} {outcome}{RESET}')
+    tally = {o: sum(1 for x in outcomes if x[1] == o) for o in
+             (acpi.WROTE, acpi.NOT_NEEDED, acpi.ASKED)}
+    print('      ' + DIM + ', '.join(
+        f'{n} {word}' for word, n in
+        (('written', tally[acpi.WROTE]),
+         ('not needed', tally[acpi.NOT_NEEDED]),
+         ('waiting on a choice', tally[acpi.ASKED])) if n) + RESET)
+
+    # anything that turned out to want an answer, plus everything never
+    # attempted. The description is the patch's own job, not the prompt it
+    # happened to print, which reads as an error rather than a choice.
+    why_asked = {name: what for _, name, what in acpi.AUTOMATIC}
+    asks = [(n, why_asked.get(n, d)) for n, o, d in outcomes if o == acpi.ASKED]
+    asks += list(acpi.ASKS)
+    print(f'\n      {DIM}{len(asks)} more need an answer only you can give:{RESET}')
+    for name, why in asks:
+        print(f'      {DIM}  {name:16s} {why}{RESET}')
+    print(f'      {DIM}The laptop profiles already carry a generic XOSI and PNLF, '
+          f'so\n      most machines need none of these.{RESET}')
+
+    if ask(0, 0, 'Open SSDTTime to work through those too?',
+           [('no', 'No, what came out is enough'),
+            ('yes', 'Yes, open the menus')]) == 'yes':
+        more, complaint = acpi.run(Path(a.out).parent / 'acpi', a.acpi_tables)
+        if more:
+            got = more
+        else:
+            print(f'      {YELLOW}{complaint}{RESET}')
+    if not got:
+        return None
+    aml, add, patches = acpi.collect(got)
+    print(f'      {GREEN}{len(aml)} SSDTs and {len(patches)} patches going in{RESET}')
+    return str(got)
+
+
 def profile_from(hw):
     """(platform, vendor, cpu, cores, oem) when detection answers all of it.
 
@@ -639,30 +691,16 @@ def main():
         where = a.acpi_tables or ('this machine' if not manual and source ==
                                   'this machine' else None)
         if where:
-            print(f'  {DIM}A laptop usually needs a few SSDTs - a fake EC, PLUG for '
-                  f'power\n  management, PNLF for the backlight - and each is written '
-                  f'against the\n  machine\'s own tables. SSDTTime does that and is '
-                  f'bundled here.{RESET}')
-            print(f'      {DIM}Six of them decide entirely from the tables and ask '
-                  f'nothing:\n      {", ".join(n for _, n, _ in acpi.AUTOMATIC)}.\n'
-                  f'      The rest ask questions only you can answer, so they are '
-                  f'in the menus.{RESET}')
-            picked = ask(0, 0, 'Work out the SSDTs now?',
-                         [('auto', 'Yes, the six that decide for themselves'),
-                          ('menu', f'Yes, and let me choose, against {where}'),
-                          ('no', 'No, the profile\'s generic SSDTs will do')])
-            if picked != 'no':
-                got, complaint = acpi.run(Path(a.out).parent / 'acpi',
-                                          a.acpi_tables,
-                                          unattended=picked == 'auto')
-                if got:
-                    aml, add, patches = acpi.collect(got)
-                    print(f'      {GREEN}{len(aml)} SSDTs and {len(patches)} '
-                          f'patches{RESET}')
-                    acpi_results = str(got)
-                else:
-                    print(f'      {YELLOW}{complaint}; the profile\'s SSDTs stay'
-                          f'{RESET}')
+            print(f'  {DIM}A machine usually needs a few SSDTs - a fake EC, PLUG '
+                  f'for power\n  management - and each is written against its own '
+                  f'tables. SSDTTime\n  does that and is bundled here. It works most '
+                  f'of them out by itself;\n  the ones that need an answer are listed '
+                  f'afterwards.{RESET}')
+            if ask(0, 0, 'Work out the SSDTs for this machine?',
+                   [('yes', 'Yes'),
+                    ('no', "No, the profile's generic SSDTs will do")]) == 'yes':
+                acpi_results = run_ssdts(a, where)
+
         else:
             print(f'  {DIM}SSDTs need the target machine\'s ACPI tables. Take them '
                   f'there with\n      detect.py --report machine.json --acpi ACPI/'


### PR DESCRIPTION
You were right that yesterday's shape was confusing. Picking "the six automatic
ones" ran them and stopped, and nothing told you the other eight existed or how
to reach them. Three answers up front - automatic, menu, no - is a puzzle to
solve before anything has happened.

Now it is linear:

```
Work out the SSDTs for this machine?
   1) Yes
   2) No, the profile's generic SSDTs will do

      SSDT-EC          written
      SSDT-PLUG        written
      SSDT-AWAC        not needed on this machine
      SSDT-PMC         written
      SSDT-HPET        needs a choice
      SSDT-SBUS-MCHC   written
      4 written, 1 not needed, 1 waiting on a choice

      8 more need an answer only you can give:
        SSDT-HPET        IRQ conflicts, if there are any
        SSDT-PNLF        laptop backlight; asks about the panel
        SSDT-XOSI        which Windows versions _OSI should answer to
        SSDT-USBX        USB power properties
        DMAR             reserved memory regions; asks which to drop
        SSDT-USB-Reset   for USB port mapping, which is its own step
        SSDT-Bridge      needs the device path of the bridge to create
        SSDT-IMEI        asks which bridge to define
      The laptop profiles already carry a generic XOSI and PNLF, so
      most machines need none of these.

Open SSDTTime to work through those too?
   1) No, what came out is enough
   2) Yes, open the menus
```

One yes/no, the outcomes, one yes/no. The choice comes after the facts.

Three things that make it readable rather than just shorter:

* **Every patch the tool can do is named**, whether it ran or not. Eight were
  invisible before; a person who needs PNLF should be told it exists rather than
  find out later.
* **Three plain outcomes** - `written`, `not needed on this machine`,
  `needs a choice` - and *written* is judged by a file appearing in the folder,
  not by scraping the last line the tool printed.
* **A patch that asks is described by what it does**, not by the prompt it
  happened to print. `SSDT-HPET  IRQ conflicts, if there are any` rather than
  `Please select an option (default is C):`, which reads as an error.

The intro no longer promises PNLF among the automatic ones, which it never was.