### PR TITLE
Read the tables before offering to use them

### DIFF
--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -766,6 +766,16 @@ def ssdt_flow():
     named = {n for n, _ in acpi.ASKS} | {n for _, n, _ in acpi.AUTOMATIC}
     check('so nothing the tool can do is invisible', len(named) >= 12, sorted(named))
 
+    src = Path('tools/setup.py').read_text()
+    # offering to work out the SSDTs and then saying "no ACPI tables were
+    # loaded" is offering something and not doing it. Building for this machine
+    # means the tables are right here.
+    flow = src[src.index('def run_ssdts('):src.index('def profile_from(')]
+    check('the tables are dumped when none were handed in',
+          'acpi.dump(' in flow and 'if not tables:' in flow)
+    check('and the menu run uses the same ones',
+          "acpi.run(Path(a.out).parent / 'acpi', tables)" in flow)
+
     if not acpi.available():
         return
     import contextlib

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -228,8 +228,23 @@ def run_ssdts(a, where):
     question about the rest. Three answers up front - automatic, menu, no - read
     as a puzzle to solve before anything has happened; this way the choice comes
     after the facts."""
+    # Building for this machine means its tables are right here, and SSDTTime
+    # can dump them. Asking "work out the SSDTs?" and then saying "no ACPI
+    # tables were loaded" is offering something and not doing it.
+    tables = a.acpi_tables
+    if not tables:
+        into = Path(a.out).parent / 'ACPI'
+        print(f'      {DIM}reading this machine\'s ACPI tables{RESET}')
+        dumped, complaint = acpi.dump(Path(a.out).parent / 'acpi-dump', into)
+        if not dumped:
+            print(f'      {YELLOW}{complaint}{RESET}')
+            return None
+        tables = str(dumped)
+        print(f'      {DIM}{len(list(Path(dumped).glob("*.aml")))} tables in '
+              f'{dumped}{RESET}')
+
     outcomes = []
-    got, complaint = acpi.run(Path(a.out).parent / 'acpi', a.acpi_tables,
+    got, complaint = acpi.run(Path(a.out).parent / 'acpi', tables,
                               unattended=True, outcomes=outcomes)
     if not got and not outcomes:
         print(f'      {YELLOW}{complaint}{RESET}')
@@ -261,7 +276,7 @@ def run_ssdts(a, where):
     if ask(0, 0, 'Open SSDTTime to work through those too?',
            [('no', 'No, what came out is enough'),
             ('yes', 'Yes, open the menus')]) == 'yes':
-        more, complaint = acpi.run(Path(a.out).parent / 'acpi', a.acpi_tables)
+        more, complaint = acpi.run(Path(a.out).parent / 'acpi', tables)
         if more:
             got = more
         else:


### PR DESCRIPTION
From your run: answering **Yes** to "Work out the SSDTs for this machine?" got
`no ACPI tables were loaded, so there is nothing to read`, and the build went
ahead with only the profile's generic SSDTs.

The offer appears when the target is this machine, but nothing ever dumped this
machine's tables - that only happened on the `--report` path. Offering something
and then not doing it is the worst of the three possible behaviours.

Now it dumps first, with the acpidump that is already sitting beside iasl:

```
Work out the SSDTs for this machine? > 1
      reading this machine's ACPI tables
      9 tables in ...\build\ACPI
      SSDT-EC          written
      ...
```

Only when the target is this machine or tables were handed in with
`--acpi-tables` - building from somebody else's report still says to take the
tables there, because dumping this machine's for their machine would be wrong.

Everything else in your run was right: `UTBMap.kext` in and `UTBDefault.kext`
out, the four SMBus kexts in the order the project gives with
`VoodooPS2...VoodooInput.kext disabled`, `0x12345678` chosen with its warning,
42 items, ocvalidate clean.

**Your current EFI has no machine-specific SSDTs.** Rebuild with the next exe if
you want them.