### PR TITLE
The macOS Apple is serving now, which the list was dropping

### DIFF
--- a/gui/Engine/Inventory.cs
+++ b/gui/Engine/Inventory.cs
@@ -96,10 +96,17 @@ public sealed class RecoveryChoice
 {
     [JsonPropertyName("version")] public string Version { get; set; } = "";
     [JsonPropertyName("name")] public string Name { get; set; } = "";
+    // what to call the row. The engine decides it, because one of these has no
+    // version to print and a window inventing its own wording for that is how
+    // two surfaces come to say different things about the same thing.
+    [JsonPropertyName("label")] public string Label { get; set; } = "";
+    [JsonPropertyName("note")] public string Note { get; set; } = "";
     [JsonPropertyName("board")] public string Board { get; set; } = "";
     [JsonPropertyName("boards")] public int Boards { get; set; }
 
-    public string Titled => $"{Name} {Version}".Trim();
+    public string Titled => Label is { Length: > 0 } said ? said
+                                                          : $"{Name} {Version}".Trim();
+    public bool Explained => Note.Length > 0;
 }
 
 public sealed class RecoveryList

--- a/gui/Views/RecoveryView.axaml
+++ b/gui/Views/RecoveryView.axaml
@@ -22,7 +22,7 @@
                       x:DataType="e:RecoveryChoice">
               <ComboBox.ItemTemplate>
                 <DataTemplate x:DataType="e:RecoveryChoice">
-                  <Grid ColumnDefinitions="150,*" ColumnSpacing="10">
+                  <Grid ColumnDefinitions="210,*" ColumnSpacing="10">
                     <TextBlock Grid.Column="0" Text="{Binding Titled}" />
                     <TextBlock Grid.Column="1" Text="{Binding Board}"
                                Classes="mono" Foreground="{DynamicResource Faint}"
@@ -31,6 +31,8 @@
                 </DataTemplate>
               </ComboBox.ItemTemplate>
             </ComboBox>
+            <TextBlock Name="Chosen" FontSize="12.5" TextWrapping="Wrap"
+                       Foreground="{DynamicResource Muted}" IsVisible="False" />
             <TextBlock Name="Provenance" FontSize="12" TextWrapping="Wrap"
                        Foreground="{DynamicResource Faint}" />
           </StackPanel>

--- a/gui/Views/RecoveryView.axaml.cs
+++ b/gui/Views/RecoveryView.axaml.cs
@@ -34,6 +34,13 @@ public partial class RecoveryView : UserControl
         Where.Text = _to;
         Target.Text = "The drive, not the EFI folder: OpenCore looks for "
                     + $"{_folder} next to EFI, at the root of the partition.";
+        // the row with no version has something to say about itself
+        Which.SelectionChanged += (_, _) =>
+        {
+            var note = (Which.SelectedItem as RecoveryChoice)?.Note ?? "";
+            Chosen.Text = note;
+            Chosen.IsVisible = note.Length > 0;
+        };
         Choose.Click += async (_, _) => await Pick();
         Fetch.Click += async (_, _) => await Get();
         Open.Click += (_, _) => Reveal.Show(Path.Combine(_to, _folder));
@@ -73,8 +80,8 @@ public partial class RecoveryView : UserControl
         Which.ItemsSource = list.Choices;
         Which.SelectedIndex = 0;
         Provenance.Text = $"{list.Choices.Count} of them, read from macrecovery's own "
-                        + "boards.json. The version is the newest Apple offers that "
-                        + "board, and the board is what the request is made with.";
+                        + "boards.json, which records the newest macOS Apple offers "
+                        + "each board. The board is what the request is made with.";
     }
 
     /// <summary>What the pane says, for the screenshot pass.

--- a/tools/provenance.py
+++ b/tools/provenance.py
@@ -288,12 +288,13 @@ def catalogue():
         dict(area='Recovery installers', kind=DERIVED,
              file='vendor/opencore/', source="macrecovery's own boards.json",
              tool='tools/recovery.py',
-             count=f'{_recoveries()} macOS versions, one board id each',
+             count=f'{_recoveries()} rows, one board id each',
              covers='which macOS Apple will serve, and the board the request '
                     'is made with',
              gap='What Apple actually returns is not known until it is asked. '
-                 'The version here is the newest that board is recorded to '
-                 'reach, not a promise about the download.'),
+                 'The version is the newest that board is recorded to reach, '
+                 'not a promise about the download - and one row has no '
+                 'version at all, because the board list gives it none.'),
         dict(area='AMD graphics kexts', kind=NONE, file='-',
              source='out of scope by request', tool='-',
              count='-', covers='-',

--- a/tools/recovery.py
+++ b/tools/recovery.py
@@ -69,8 +69,9 @@ def choices(tool=None):
     the argument the download actually takes, so this is the list and the
     answer at once.
 
-    The "latest" boards are left out. They are the ones Apple keeps moving, so
-    what they return today is not something this can name in advance."""
+    Six boards are recorded as `latest` rather than a version. Those are the
+    ones Apple keeps current, so they are how you ask for whatever macOS is
+    newest today; what that is cannot be named here, and is not."""
     tool = tool or vendored()
     if tool is None:
         return []
@@ -81,26 +82,41 @@ def choices(tool=None):
     names = _names()
     out = []
     for version, ids in grouped.items():
-        if not version[0].isdigit():
-            continue
-        short = version.rsplit('.', 1)[0] if version.startswith('10.') else version.split('.')[0]
+        named = version[0].isdigit()
+        short = (version.rsplit('.', 1)[0] if version.startswith('10.')
+                 else version.split('.')[0]) if named else ''
+        name = names.get(short, '')
         out.append({
             'version': version,
-            'name': names.get(short, ''),
+            'name': name,
+            # what a person is offered. One place decides it, so a window and
+            # a terminal cannot word the same row differently.
+            'label': f'{name} {version}'.strip() if named
+                     else 'Whatever Apple serves now',
+            'note': '' if named else
+                    'these boards are kept current, so this is the newest macOS '
+                    'Apple is serving today - the board list does not name it in '
+                    'advance, and neither does this',
             # deterministic: the same board every time, so two people asking
-            # for the same macOS ask Apple the same question
+            # for the same macOS ask Apple the same question. For the current
+            # one that lands on macrecovery's own default, which is the board
+            # the tool uses when nobody names one.
             'board': sorted(ids)[0],
             'boards': len(ids),
         })
-    out.sort(key=lambda c: [int(n) for n in c['version'].split('.')], reverse=True)
+    # newest first, and the one with no number is newer than all of them
+    out.sort(reverse=True, key=lambda c: [int(n) for n in c['version'].split('.')]
+             if c['version'][0].isdigit() else [10 ** 6])
     return out
 
 
 def find(wanted, tool=None):
-    """One choice, by version or by name. None if nothing matches."""
+    """One choice, by version, by name, or by 'latest'. None if nothing matches."""
     asked = (wanted or '').strip().lower()
     for choice in choices(tool):
-        if asked in (choice['version'].lower(), choice['name'].lower()):
+        if asked and asked in (choice['version'].lower(),
+                               choice['name'].lower(),
+                               choice['label'].lower()):
             return choice
     return None
 
@@ -246,9 +262,8 @@ def _size(count):
 
 def describe(choice, files):
     """What was fetched, in the terms the person asked in."""
-    named = f"{choice['name']} {choice['version']}".strip()
     total = sum(size for _, size in files) / (1024 * 1024)
-    return f'{named}, {len(files)} files, {total:.0f} MB'
+    return f"{choice['label']}, {len(files)} files, {total:.0f} MB"
 
 
 def main(argv=None):
@@ -269,10 +284,13 @@ def main(argv=None):
     if a.list or not a.macos:
         print(f'{BOLD}Recovery installers Apple will serve{RESET}')
         for choice in choices(tool):
-            print(f"  {choice['version']:9} {choice['name']:12} "
+            print(f"  {choice['version']:9} {choice['label']:28} "
                   f"{choice['board']}  {DIM}({choice['boards']} boards){RESET}")
-        print(f"{DIM}\n  read from macrecovery's own boards.json; the version is "
-              f"the newest\n  each board is offered.{RESET}")
+            if choice['note']:
+                print(f"{DIM}            {choice['note']}{RESET}")
+        print(f"{DIM}\n  read from macrecovery's own boards.json, which records the "
+              f"newest macOS\n  each board is offered. Ask for one by version, by "
+              f"name, or 'latest'.{RESET}")
         return 0
 
     choice = find(a.macos, tool)
@@ -289,8 +307,7 @@ def main(argv=None):
               f'somebody may be part way through{RESET}')
         return 1
 
-    print(f"{BOLD}Fetching {choice['name']} {choice['version']} "
-          f"from Apple{RESET}")
+    print(f"{BOLD}Fetching {choice['label']} from Apple{RESET}")
     print(f"{DIM}  board {choice['board']}, serial {NO_SERIAL}, into "
           f"{Path(a.out) / FOLDER}{RESET}")
     files, complaint = fetch(choice, a.out, tool)

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -2109,9 +2109,10 @@ def the_recovery_it_can_fetch():
     boards = _json.loads((tool.parent / 'boards.json').read_text(encoding='utf-8'))
     offered = recovery.choices()
     check('there is something to fetch', len(offered) >= 5, len(offered))
+    numbered = [c for c in offered if c['version'][0].isdigit()]
     check('newest first',
-          offered == sorted(offered, reverse=True,
-                            key=lambda c: [int(n) for n in c['version'].split('.')]))
+          numbered == sorted(numbered, reverse=True,
+                             key=lambda c: [int(n) for n in c['version'].split('.')]))
     check('one entry per macOS',
           len({c['version'] for c in offered}) == len(offered))
     for choice in offered:
@@ -2119,10 +2120,30 @@ def the_recovery_it_can_fetch():
         # to that version, or the request asks Apple for something else
         check(f"{choice['version']} names a board that yields it",
               boards.get(choice['board']) == choice['version'], choice)
-        check(f"{choice['version']} has the name people know it by",
-              choice['name'], choice)
-    check('the boards Apple keeps moving are left out',
-          all(c['version'][0].isdigit() for c in offered))
+        check(f"{choice['version']} is offered under a name",
+              choice['label'], choice)
+    for choice in numbered:
+        check(f"{choice['version']} is named as people know it",
+              choice['name'] and choice['name'] in choice['label'], choice)
+
+    # the boards Apple keeps current are how somebody asks for the macOS that
+    # is newest today. Dropping them meant the newest release could not be
+    # fetched at all, which is what it looked like from the window.
+    current = [c for c in offered if not c['version'][0].isdigit()]
+    check('the macOS Apple is serving now can be asked for', len(current) == 1,
+          [c['version'] for c in current])
+    if current:
+        check('and it comes first', offered[0] is current[0])
+        check('named for what it is, since nothing here knows the number',
+              not any(ch.isdigit() for ch in current[0]['label']),
+              current[0]['label'])
+        check('and it says why it has no version', current[0]['note'])
+        check('the numbered ones do not need saying',
+              not any(c['note'] for c in numbered))
+        check('and it can be asked for by that word',
+              recovery.find('latest') == current[0])
+    check('every row can be asked for by its own version',
+          all(recovery.find(c['version']) == c for c in offered))
     check('and it lands where OpenCore looks',
           recovery.FOLDER == 'com.apple.recovery.boot')
 
@@ -2157,6 +2178,9 @@ def the_recovery_it_can_fetch():
               'Inventory.Recoveries' in drawn)
         check('and streams the download rather than waiting on it',
               'Builder.Stream' in drawn)
+    model = Path('gui/Engine/Inventory.cs').read_text()
+    check('the window shows the name the engine chose, not one of its own',
+          '"label"' in model and 'Label is { Length: > 0 }' in model)
     # every pane that reads on first sight waits on the same read. A bool
     # guard let the second caller through while the first was still awaiting -
     # the nav starts a Swap of its own, so two always arrive together - and the


### PR DESCRIPTION
`boards.json` gives most board ids a version and six of them the word `latest`.
Those six are the boards Apple keeps current — they are how you ask for the
newest macOS there is — and the list dropped them, so the newest release could
not be fetched at all. From the window it looked like Tahoe was missing.

They are one row now, at the top, called "Whatever Apple serves now". It is not
labelled with a version because nothing here has one to give: the board list
names none, and Apple decides at request time. The row says so.

The board is `Mac-27AD2F918AE68F61`, which is both the first of the six by the
same rule every other row uses and macrecovery's own default.

Verified against Apple: 916 MB, chunklist verified, and the image mounts as
macOS 26.6.2.

Also: the engine now sends the label and the note, rather than the window
wording a versionless row for itself.