### PR TITLE
The number is the board's ceiling, not the image that arrives

### DIFF
--- a/gui/Views/RecoveryView.axaml
+++ b/gui/Views/RecoveryView.axaml
@@ -22,9 +22,14 @@
                       x:DataType="e:RecoveryChoice">
               <ComboBox.ItemTemplate>
                 <DataTemplate x:DataType="e:RecoveryChoice">
-                  <Grid ColumnDefinitions="210,*" ColumnSpacing="10">
+                  <Grid ColumnDefinitions="210,*,Auto" ColumnSpacing="10">
                     <TextBlock Grid.Column="0" Text="{Binding Titled}" />
                     <TextBlock Grid.Column="1" Text="{Binding Board}"
+                               Classes="mono" Foreground="{DynamicResource Faint}"
+                               VerticalAlignment="Center" />
+                    <!-- the board's ceiling, not the image that arrives. The
+                         note under the box says which is which. -->
+                    <TextBlock Grid.Column="2" Text="{Binding Version}"
                                Classes="mono" Foreground="{DynamicResource Faint}"
                                VerticalAlignment="Center" />
                   </Grid>

--- a/tools/README.md
+++ b/tools/README.md
@@ -107,9 +107,22 @@ is the joining up: which macOS, where it goes, and what to do next.
 
 The list is not kept here. `boards.json` travels with `macrecovery` and records,
 for each board id, the newest macOS Apple offers it; grouping by that gives one
-entry per macOS, and the board id is the argument the request is made with. The
-six boards mapped to `latest` are left out - what they return today is not
-something this can name in advance.
+entry per macOS, and the board id is the argument the request is made with. Six
+boards are recorded as `latest` rather than a version: those are the ones Apple
+keeps current, so they are how to ask for the newest macOS there is, and what
+that turns out to be is not named in advance because nothing here knows it.
+
+A row is named, not numbered, and the number sits beside it as what it is. The
+board list's version is that board's ceiling, not the image Apple hands back -
+measured, twice:
+
+    asked for            Apple served
+    12.7.6 board         BaseSystem 12.6      (21G115)
+    latest board         BaseSystem 26.6.2    (25G83)
+
+Recovery downloads the rest of macOS during the install, so what gets installed
+is current either way. Printing "Monterey 12.7.6" on a row that fetches a 12.6
+image would be a claim this cannot keep.
 
 It writes `com.apple.recovery.boot` at the root of the drive, beside `EFI`,
 which is where OpenCore looks. A run that fails takes back what it wrote: there

--- a/tools/provenance.py
+++ b/tools/provenance.py
@@ -291,10 +291,10 @@ def catalogue():
              count=f'{_recoveries()} rows, one board id each',
              covers='which macOS Apple will serve, and the board the request '
                     'is made with',
-             gap='What Apple actually returns is not known until it is asked. '
-                 'The version is the newest that board is recorded to reach, '
-                 'not a promise about the download - and one row has no '
-                 'version at all, because the board list gives it none.'),
+             gap='The version is the newest that board is recorded to reach, '
+                 'not the image Apple hands back: the 12.7.6 board served a '
+                 '12.6 BaseSystem. One row has no version at all, because the '
+                 'board list gives it none.'),
         dict(area='AMD graphics kexts', kind=NONE, file='-',
              source='out of scope by request', tool='-',
              count='-', covers='-',

--- a/tools/recovery.py
+++ b/tools/recovery.py
@@ -89,11 +89,20 @@ def choices(tool=None):
         out.append({
             'version': version,
             'name': name,
-            # what a person is offered. One place decides it, so a window and
+            # What a person is offered. One place decides it, so a window and
             # a terminal cannot word the same row differently.
-            'label': f'{name} {version}'.strip() if named
-                     else 'Whatever Apple serves now',
-            'note': '' if named else
+            #
+            # The name, not the number. The number is the newest macOS the
+            # board list records for that board, which is not the image Apple
+            # hands back: asked for the 12.7.6 board, Apple served a 12.6
+            # BaseSystem. Recovery then fetches the rest, so what gets
+            # installed is a current build - but printing "Monterey 12.7.6" on
+            # a row that downloads 12.6 is a claim nothing here can keep.
+            'label': name or version if named else 'Whatever Apple serves now',
+            'note': (f'the board list records {version} as the newest this board '
+                     f'reaches. The image Apple hands back is some build of '
+                     f'{name or version}; recovery downloads the rest during the '
+                     f'install.') if named else
                     'these boards are kept current, so this is the newest macOS '
                     'Apple is serving today - the board list does not name it in '
                     'advance, and neither does this',
@@ -284,13 +293,14 @@ def main(argv=None):
     if a.list or not a.macos:
         print(f'{BOLD}Recovery installers Apple will serve{RESET}')
         for choice in choices(tool):
-            print(f"  {choice['version']:9} {choice['label']:28} "
-                  f"{choice['board']}  {DIM}({choice['boards']} boards){RESET}")
-            if choice['note']:
-                print(f"{DIM}            {choice['note']}{RESET}")
-        print(f"{DIM}\n  read from macrecovery's own boards.json, which records the "
-              f"newest macOS\n  each board is offered. Ask for one by version, by "
-              f"name, or 'latest'.{RESET}")
+            print(f"  {choice['label']:28} {choice['board']}  "
+                  f"{DIM}{choice['version']:9} {choice['boards']} boards{RESET}")
+        print(f"{DIM}\n  The number is what the board list records as that board's "
+              f"newest, not\n  the image Apple hands back: asked for the 12.7.6 "
+              f"board it served a 12.6\n  BaseSystem. Recovery downloads the rest "
+              f"during the install.{RESET}")
+        print(f"{DIM}  Read from macrecovery's own boards.json. Ask for one by "
+              f"version, by name,\n  or 'latest'.{RESET}")
         return 0
 
     choice = find(a.macos, tool)

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -2126,6 +2126,7 @@ def the_recovery_it_can_fetch():
         check(f"{choice['version']} is named as people know it",
               choice['name'] and choice['name'] in choice['label'], choice)
 
+
     # the boards Apple keeps current are how somebody asks for the macOS that
     # is newest today. Dropping them meant the newest release could not be
     # fetched at all, which is what it looked like from the window.
@@ -2138,8 +2139,15 @@ def the_recovery_it_can_fetch():
               not any(ch.isdigit() for ch in current[0]['label']),
               current[0]['label'])
         check('and it says why it has no version', current[0]['note'])
-        check('the numbered ones do not need saying',
-              not any(c['note'] for c in numbered))
+    # the number is the board's ceiling, not the image: asked for the 12.7.6
+    # board Apple served a 12.6 BaseSystem. Printing the number as the name
+    # would be a promise nothing here can keep, so the row is named and the
+    # number is explained beside it.
+    for choice in numbered:
+        check(f"{choice['version']} is offered by name, not by number",
+              choice['label'] == choice['name'], choice['label'])
+        check(f"{choice['version']} says what the number is",
+              choice['version'] in choice['note'], choice['note'])
         check('and it can be asked for by that word',
               recovery.find('latest') == current[0])
     check('every row can be asked for by its own version',


### PR DESCRIPTION
The rows said "Monterey 12.7.6". Mounted what actually came down:

    asked for            Apple served
    12.7.6 board         BaseSystem 12.6      (21G115)
    latest board         BaseSystem 26.6.2    (25G83)

`boards.json` records the newest macOS a board *reaches*, which is not the
image Apple hands back for it. Recovery downloads the rest during the install,
so what gets installed is current either way - but a row that fetches 12.6
should not be labelled 12.7.6.

Rows are named now, with the number beside them and a sentence saying which is
which.