### PR TITLE
The stick: find it, format it, put both folders on it

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -101,6 +101,13 @@ jobs:
             render.log \
             || { echo 'the recovery pane listed nothing'; cat render.log; exit 1; }
 
+          # the stick pane on a machine with no stick in it. Zero is the right
+          # answer here and the pane has to reach it rather than throw - and
+          # nothing in this pass erases anything.
+          grep -qE 'stick: [0-9]+ sticks, erasable=(True|False), into com.apple.recovery.boot' \
+            render.log \
+            || { echo 'the stick pane did not report'; cat render.log; exit 1; }
+
       # A font that failed to load falls back to the system's, and the window
       # still looks reasonable. That is the whole problem: it has to be checked,
       # not eyeballed.

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -104,7 +104,7 @@ jobs:
           # the stick pane on a machine with no stick in it. Zero is the right
           # answer here and the pane has to reach it rather than throw - and
           # nothing in this pass erases anything.
-          grep -qE 'stick: [0-9]+ sticks, erasable=(True|False), into com.apple.recovery.boot' \
+          grep -qE 'stick: [0-9]+ sticks, [0-9]+ ready, erasable=(True|False), into com.apple.recovery.boot' \
             render.log \
             || { echo 'the stick pane did not report'; cat render.log; exit 1; }
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ __pycache__/
 
 # a published build dropped in for trying by hand
 gui/dist/
+
+# The window's build output. `dotnet build` writes it here, and an EFI or a
+# downloaded recovery lands beside the binary - a git add -A once swept a
+# 916 MB BaseSystem.dmg into a commit.
+gui/bin/
+gui/obj/

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ open it.
 beside it. That is the file to carry to the computer you build on when the USB
 is being prepared somewhere else.
 
+**USB stick** finds the removable disks, formats one if you want, and copies
+both folders onto it in the right places. It lists removable disks only and
+never the one the computer booted from, and it asks for the disk by name before
+erasing anything.
+
 **Recovery** puts Apple's own installer on the stick beside the EFI - about
 700 MB that boots, connects, and downloads the rest of macOS itself. It is the
 answer when a whole image will not fit: the FAT32 partition an EFI lives on
@@ -328,6 +333,38 @@ To check if your hardware is incompatible, I leave links below.
 - Copy that file into `EFI/OC/` and rename it to `config.plist`.
 - Copy the `EFI` folder to the EFI partition.
 - Now you can boot from USB.
+
+<br>
+
+#### With the recovery installer instead of an image
+
+If you took the recovery from the app's Recovery tab, there is no macOS image
+to write and the stick is a plain one. Format it as **GUID Partition Map** with
+a single **MS-DOS (FAT)** partition - on macOS that is Disk Utility with
+*View → Show All Devices*, selecting the drive itself rather than the volume
+under it, or:
+
+```
+diskutil list                                        # find the disk number
+diskutil eraseDisk MS-DOS USB GPT /dev/diskN         # N is that number
+```
+
+Then put both folders at the root of it, side by side:
+
+```
+/Volumes/USB/
+├── EFI/                       the folder the builder wrote
+└── com.apple.recovery.boot/   BaseSystem.dmg + BaseSystem.chunklist
+```
+
+That is the whole stick. Nothing goes inside `EFI` that was not already there,
+and the recovery folder is not inside it either - OpenCore looks for that name
+beside itself. Boot from the USB and the OpenCore picker lists **macOS Base
+System**; pick it, and the installer downloads the rest of macOS itself.
+
+A 2 GB stick is enough: the recovery is under a gigabyte and the EFI is about
+7 MB. The machine needs Ethernet or a Wi-Fi card macOS already drives while it
+installs, because that download happens on the machine being converted.
 
 <br>
 

--- a/gui/App.axaml.cs
+++ b/gui/App.axaml.cs
@@ -60,8 +60,8 @@ public partial class App : Application
                 try
                 {
                     Console.WriteLine("drive: " + await window.DriveBuilder());
-                    foreach (var pane in new[] { "report", "recovery", "devices",
-                                                 "kexts", "about" })
+                    foreach (var pane in new[] { "report", "recovery", "stick",
+                                                 "devices", "kexts", "about" })
                     {
                         await window.Show(pane);
                         // the report pane's whole job is behind a button, so
@@ -73,6 +73,11 @@ public partial class App : Application
                         // was up - the pane's own job is to offer the list.
                         if (pane == "recovery")
                             Console.WriteLine("recovery: " + await window.ListRecoveries());
+                        // listed, not written to. A build machine has no stick
+                        // in it, and the interesting thing is that the pane
+                        // says so rather than offering the disk it booted from.
+                        if (pane == "stick")
+                            Console.WriteLine("stick: " + await window.ListSticks());
                         // one turn of the loop, so what was just loaded is laid
                         // out before its picture is taken
                         await Task.Delay(1200);

--- a/gui/Engine/Inventory.cs
+++ b/gui/Engine/Inventory.cs
@@ -123,9 +123,17 @@ public sealed class Stick
     [JsonPropertyName("size")] public string Size { get; set; } = "";
     [JsonPropertyName("bus")] public string Bus { get; set; } = "";
     [JsonPropertyName("mounted")] public List<string> Mounted { get; set; } = new();
+    [JsonPropertyName("scheme")] public string Scheme { get; set; } = "";
+    // whether it can be copied to as it stands, where to, and why. The engine
+    // decides: "is this a USB stick" is not the question, "is this FAT32" is.
+    [JsonPropertyName("ready")] public bool Ready { get; set; }
+    [JsonPropertyName("write_to")] public string WriteTo { get; set; } = "";
+    [JsonPropertyName("why")] public string Why { get; set; } = "";
 
     public string Titled => $"{Name} · {Size}".Trim();
-    public string Where => Mounted.Count > 0 ? Mounted[0] : "";
+    public string Where => WriteTo.Length > 0 ? WriteTo
+                         : Mounted.Count > 0 ? Mounted[0] : "";
+    public string State => Ready ? "ready" : "needs formatting";
 }
 
 public sealed class StickList

--- a/gui/Engine/Inventory.cs
+++ b/gui/Engine/Inventory.cs
@@ -116,6 +116,28 @@ public sealed class RecoveryList
     [JsonPropertyName("choices")] public List<RecoveryChoice> Choices { get; set; } = new();
 }
 
+public sealed class Stick
+{
+    [JsonPropertyName("device")] public string Device { get; set; } = "";
+    [JsonPropertyName("name")] public string Name { get; set; } = "";
+    [JsonPropertyName("size")] public string Size { get; set; } = "";
+    [JsonPropertyName("bus")] public string Bus { get; set; } = "";
+    [JsonPropertyName("mounted")] public List<string> Mounted { get; set; } = new();
+
+    public string Titled => $"{Name} · {Size}".Trim();
+    public string Where => Mounted.Count > 0 ? Mounted[0] : "";
+}
+
+public sealed class StickList
+{
+    [JsonPropertyName("platform")] public string Platform { get; set; } = "";
+    [JsonPropertyName("booted")] public string? Booted { get; set; }
+    [JsonPropertyName("erasable")] public bool Erasable { get; set; }
+    [JsonPropertyName("recovery")] public string Recovery { get; set; } = "";
+    [JsonPropertyName("sticks")] public List<Stick> Sticks { get; set; } = new();
+}
+
+[JsonSerializable(typeof(StickList))]
 [JsonSerializable(typeof(RecoveryList))]
 [JsonSerializable(typeof(DeviceList))]
 [JsonSerializable(typeof(KextList))]
@@ -155,6 +177,17 @@ public static class Inventory
         try
         {
             return (JsonSerializer.Deserialize(output, Carried.Default.RecoveryList), "");
+        }
+        catch (JsonException e) { return (null, e.Message); }
+    }
+
+    public static async Task<(StickList? list, string complaint)> Sticks(Located engine)
+    {
+        var (output, error, code) = await Builder.Run(engine, "--usb-list");
+        if (code != 0) return (null, Said(error, code));
+        try
+        {
+            return (JsonSerializer.Deserialize(output, Carried.Default.StickList), "");
         }
         catch (JsonException e) { return (null, e.Message); }
     }

--- a/gui/Views/MainWindow.axaml
+++ b/gui/Views/MainWindow.axaml
@@ -43,6 +43,8 @@
           <RadioButton Name="ToReport" Classes="nav" GroupName="pane" Content="Report" />
           <RadioButton Name="ToRecovery" Classes="nav" GroupName="pane"
                        Content="Recovery" />
+          <RadioButton Name="ToStick" Classes="nav" GroupName="pane"
+                       Content="USB stick" />
           <RadioButton Name="ToDevices" Classes="nav" GroupName="pane"
                        Content="Compatible Hardware" />
           <RadioButton Name="ToKexts" Classes="nav" GroupName="pane" Content="Kexts" />
@@ -61,6 +63,7 @@
       <v:BuilderView Name="BuilderPane" IsVisible="False" />
       <v:ReportView Name="ReportPane" IsVisible="False" />
       <v:RecoveryView Name="RecoveryPane" IsVisible="False" />
+      <v:StickView Name="StickPane" IsVisible="False" />
       <v:DevicesView Name="DevicesPane" IsVisible="False" />
       <v:KextsView Name="KextsPane" IsVisible="False" />
       <v:AboutView Name="AboutPane" IsVisible="False" />

--- a/gui/Views/MainWindow.axaml.cs
+++ b/gui/Views/MainWindow.axaml.cs
@@ -10,7 +10,7 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         foreach (var nav in new[] { ToMachine, ToBuilder, ToReport, ToRecovery,
-                                    ToDevices, ToKexts, ToAbout })
+                                    ToStick, ToDevices, ToKexts, ToAbout })
             nav.IsCheckedChanged += async (_, _) => await Swap();
         _ = Standing();
     }
@@ -38,12 +38,14 @@ public partial class MainWindow : Window
         BuilderPane.IsVisible = ToBuilder.IsChecked == true;
         ReportPane.IsVisible = ToReport.IsChecked == true;
         RecoveryPane.IsVisible = ToRecovery.IsChecked == true;
+        StickPane.IsVisible = ToStick.IsChecked == true;
         DevicesPane.IsVisible = ToDevices.IsChecked == true;
         KextsPane.IsVisible = ToKexts.IsChecked == true;
         AboutPane.IsVisible = ToAbout.IsChecked == true;
         // read on first sight rather than at startup: opening the program
         // should not wait on three documents nobody has asked for yet
         if (ToRecovery.IsChecked == true) await RecoveryPane.Load();
+        if (ToStick.IsChecked == true) await StickPane.Load();
         if (ToDevices.IsChecked == true) await DevicesPane.Load();
         if (ToKexts.IsChecked == true) await KextsPane.Load();
         if (ToAbout.IsChecked == true) await AboutPane.Load();
@@ -62,6 +64,8 @@ public partial class MainWindow : Window
 
     public Task<string> ListRecoveries() => RecoveryPane.ListForRender();
 
+    public Task<string> ListSticks() => StickPane.ListForRender();
+
     public Task<string> DriveBuilder() => BuilderPane.DriveToEnd();
 
     /// <summary>Show one pane by name, for the screenshot pass.</summary>
@@ -69,7 +73,7 @@ public partial class MainWindow : Window
     {
         var nav = pane switch
         {
-            "report" => ToReport, "recovery" => ToRecovery,
+            "report" => ToReport, "recovery" => ToRecovery, "stick" => ToStick,
             "devices" => ToDevices, "kexts" => ToKexts,
             "about" => ToAbout,
             "builder" => ToBuilder, _ => ToMachine,

--- a/gui/Views/StickView.axaml
+++ b/gui/Views/StickView.axaml
@@ -1,0 +1,94 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:v="clr-namespace:Shell.Views"
+             xmlns:e="clr-namespace:Shell.Engine"
+             x:Class="Shell.Views.StickView"
+             x:DataType="v:StickView">
+  <ScrollViewer>
+    <StackPanel Margin="28,24" Spacing="20" MaxWidth="760" HorizontalAlignment="Left">
+      <StackPanel Spacing="8">
+        <TextBlock Classes="eyebrow" Text="THE USB STICK" />
+        <TextBlock FontSize="15" TextWrapping="Wrap" Foreground="{DynamicResource Ink}"
+                   Text="Put the EFI and the installer on it." />
+        <TextBlock FontSize="13.5" TextWrapping="Wrap" Foreground="{DynamicResource Muted}"
+                   Text="Both folders go at the root of the stick, side by side - the recovery does not go inside the EFI folder, because OpenCore looks for it beside itself. Only removable disks are listed here, and never the one this computer booted from." />
+      </StackPanel>
+
+      <Border Classes="panel">
+        <StackPanel Spacing="14">
+          <StackPanel Spacing="6">
+            <Grid ColumnDefinitions="*,Auto">
+              <TextBlock Grid.Column="0" Classes="eyebrow" Text="WHICH STICK"
+                         VerticalAlignment="Center" />
+              <Button Grid.Column="1" Name="Again" Content="Look again" />
+            </Grid>
+            <ComboBox Name="Which" HorizontalAlignment="Stretch"
+                      x:DataType="e:Stick">
+              <ComboBox.ItemTemplate>
+                <DataTemplate x:DataType="e:Stick">
+                  <Grid ColumnDefinitions="260,*,Auto" ColumnSpacing="10">
+                    <TextBlock Grid.Column="0" Text="{Binding Titled}" />
+                    <TextBlock Grid.Column="1" Text="{Binding Where}"
+                               Classes="mono" Foreground="{DynamicResource Faint}"
+                               VerticalAlignment="Center" />
+                    <TextBlock Grid.Column="2" Text="{Binding Device}"
+                               Classes="mono" Foreground="{DynamicResource Faint}"
+                               VerticalAlignment="Center" />
+                  </Grid>
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+            <TextBlock Name="Found" FontSize="12" TextWrapping="Wrap"
+                       Foreground="{DynamicResource Faint}" />
+          </StackPanel>
+
+          <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+            <TextBlock Grid.Column="0" Classes="eyebrow" Text="EFI"
+                       VerticalAlignment="Center" Width="70" />
+            <TextBlock Grid.Column="1" Name="EfiFrom" Classes="mono"
+                       VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+            <Button Grid.Column="2" Name="PickEfi" Content="Change…" />
+          </Grid>
+          <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
+            <TextBlock Grid.Column="0" Classes="eyebrow" Text="INSTALLER"
+                       VerticalAlignment="Center" Width="70" />
+            <TextBlock Grid.Column="1" Name="RecoveryFrom" Classes="mono"
+                       VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+            <Button Grid.Column="2" Name="PickRecovery" Content="Change…" />
+          </Grid>
+
+          <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Left">
+            <Button Name="Copy" Content="Copy onto the stick" Classes="accent" />
+            <Button Name="Open" Content="Show the stick" IsVisible="False" />
+          </StackPanel>
+        </StackPanel>
+      </Border>
+
+      <!-- Erasing is the only thing here that destroys something, so it is
+           its own panel, folded away, and asks for the disk by name. -->
+      <Expander Name="EraseBox" Header="Erase and format it first">
+        <StackPanel Spacing="12" Margin="0,8,0,0">
+          <TextBlock Name="EraseWhat" FontSize="13.5" TextWrapping="Wrap"
+                     Foreground="{DynamicResource Ink}" />
+          <TextBlock Name="EraseHow" FontSize="12.5" TextWrapping="Wrap"
+                     Foreground="{DynamicResource Muted}" />
+          <StackPanel Name="EraseAsk" Spacing="8">
+            <TextBox Name="Typed" Watermark="type the disk name to confirm"
+                     HorizontalAlignment="Left" Width="260" />
+            <Button Name="Erase" Content="Erase it" IsEnabled="False" />
+          </StackPanel>
+        </StackPanel>
+      </Expander>
+
+      <Border Name="Result" Classes="panel" IsVisible="False">
+        <StackPanel Spacing="8">
+          <TextBlock Name="ResultTitle" FontSize="15" FontWeight="SemiBold"
+                     Foreground="{DynamicResource Ink}" />
+          <TextBlock Name="ResultText" Classes="mono" TextWrapping="Wrap" />
+          <TextBlock Name="ResultNext" FontSize="12.5" TextWrapping="Wrap"
+                     Foreground="{DynamicResource Muted}" IsVisible="False" />
+        </StackPanel>
+      </Border>
+    </StackPanel>
+  </ScrollViewer>
+</UserControl>

--- a/gui/Views/StickView.axaml
+++ b/gui/Views/StickView.axaml
@@ -28,7 +28,7 @@
                 <DataTemplate x:DataType="e:Stick">
                   <Grid ColumnDefinitions="260,*,Auto" ColumnSpacing="10">
                     <TextBlock Grid.Column="0" Text="{Binding Titled}" />
-                    <TextBlock Grid.Column="1" Text="{Binding Where}"
+                    <TextBlock Grid.Column="1" Text="{Binding State}"
                                Classes="mono" Foreground="{DynamicResource Faint}"
                                VerticalAlignment="Center" />
                     <TextBlock Grid.Column="2" Text="{Binding Device}"
@@ -38,6 +38,17 @@
                 </DataTemplate>
               </ComboBox.ItemTemplate>
             </ComboBox>
+            <!-- the answer to "do I need to format this?", which is the
+                 question a stick actually raises -->
+            <Border Name="VerdictBox" CornerRadius="6" Padding="12,10"
+                    IsVisible="False">
+              <StackPanel Spacing="4">
+                <TextBlock Name="VerdictWhat" FontSize="13.5" FontWeight="SemiBold"
+                           TextWrapping="Wrap" />
+                <TextBlock Name="VerdictWhy" FontSize="12.5" TextWrapping="Wrap"
+                           Foreground="{DynamicResource Muted}" />
+              </StackPanel>
+            </Border>
             <TextBlock Name="Found" FontSize="12" TextWrapping="Wrap"
                        Foreground="{DynamicResource Faint}" />
           </StackPanel>

--- a/gui/Views/StickView.axaml.cs
+++ b/gui/Views/StickView.axaml.cs
@@ -13,7 +13,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Media;
 using Avalonia.Platform.Storage;
+using Avalonia;
 using Shell.Engine;
 
 namespace Shell.Views;
@@ -73,8 +75,10 @@ public partial class StickView : UserControl
         _folder = list.Recovery;
         _erasable = list.Erasable;
         Which.ItemsSource = list.Sticks;
-        Which.SelectedIndex = list.Sticks.Count > 0 ? 0 : -1;
-        Copy.IsEnabled = list.Sticks.Count > 0;
+        // the one that is ready, if any: a person with two sticks in wants the
+        // one they do not have to erase
+        var ready = list.Sticks.FindIndex(s => s.Ready);
+        Which.SelectedIndex = list.Sticks.Count == 0 ? -1 : ready >= 0 ? ready : 0;
         Found.Text = list.Sticks.Count switch
         {
             0 => "No removable disk is plugged in. This only ever lists removable, "
@@ -92,18 +96,36 @@ public partial class StickView : UserControl
     {
         await Load();
         var sticks = Which.ItemsSource as IEnumerable<Stick>;
-        var count = sticks?.Count() ?? 0;
-        return $"{count} sticks, erasable={_erasable}, into {_folder}";
+        var all = sticks?.ToList() ?? new List<Stick>();
+        var ready = all.Count(s => s.Ready);
+        return $"{all.Count} sticks, {ready} ready, erasable={_erasable}, "
+             + $"into {_folder}";
     }
 
     void Describe()
     {
         if (Which.SelectedItem is not Stick stick)
         {
-            EraseBox.IsVisible = false;
+            EraseBox.IsVisible = VerdictBox.IsVisible = false;
             Open.IsVisible = false;
+            Copy.IsEnabled = false;
             return;
         }
+
+        // the question a stick raises is "do I have to format this?", so that
+        // is answered before anything else on the pane
+        VerdictBox.IsVisible = true;
+        VerdictBox.Background = Brush("OkSoft", "WarnSoft", stick.Ready);
+        VerdictWhat.Foreground = Brush("Ok", "Warn", stick.Ready);
+        VerdictWhat.Text = stick.Ready
+            ? $"Ready. Writes to {stick.WriteTo}"
+            : "This one has to be formatted first";
+        VerdictWhy.Text = stick.Why;
+
+        Copy.IsEnabled = stick.Ready;
+        // and when it does need formatting, the way to do that is open rather
+        // than folded away behind a heading nobody clicks
+        EraseBox.IsExpanded = !stick.Ready;
         EraseBox.IsVisible = true;
         Open.IsVisible = stick.Where.Length > 0;
         EraseWhat.Text = $"This erases everything on {stick.Name}, {stick.Size} "
@@ -121,6 +143,9 @@ public partial class StickView : UserControl
         Typed.Text = "";
         if (!_erasable) Erase.IsEnabled = true;
     }
+
+    IBrush Brush(string good, string bad, bool ready) =>
+        (IBrush)(Application.Current!.FindResource(ready ? good : bad) ?? Brushes.Gray);
 
     async Task Pick(bool efi)
     {

--- a/gui/Views/StickView.axaml.cs
+++ b/gui/Views/StickView.axaml.cs
@@ -1,0 +1,217 @@
+// The USB stick: what to write, and where.
+//
+// The engine finds the disks and does the writing. This pane is the picking
+// and the asking - and the asking matters, because erasing is the only thing
+// this program does that cannot be undone.
+//
+// What actually stops the wrong disk is not the question in front of it: the
+// engine refuses any device its own list did not offer, checked again at the
+// moment it runs. The question is here so nobody is surprised.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Shell.Engine;
+
+namespace Shell.Views;
+
+public partial class StickView : UserControl
+{
+    // copying 900 MB to a slow stick is not a hang
+    static readonly TimeSpan Bound = TimeSpan.FromMinutes(30);
+
+    string _efi = Path.Combine(AppContext.BaseDirectory, "EFI");
+    string _recovery = AppContext.BaseDirectory;
+    string _folder = "com.apple.recovery.boot";
+    bool _erasable;
+    Task? _loaded;
+
+    public StickView()
+    {
+        InitializeComponent();
+        EfiFrom.Text = _efi;
+        RecoveryFrom.Text = _recovery;
+        Again.Click += async (_, _) => { _loaded = null; await Load(); };
+        PickEfi.Click += async (_, _) => await Pick(true);
+        PickRecovery.Click += async (_, _) => await Pick(false);
+        Copy.Click += async (_, _) => await CopyOn();
+        Erase.Click += async (_, _) => await EraseIt();
+        Which.SelectionChanged += (_, _) => Describe();
+        // the button turns on only when what is typed is the disk that is
+        // selected. A checkbox would be a habit; this has to be read.
+        Typed.TextChanged += (_, _) =>
+            Erase.IsEnabled = _erasable
+                && Which.SelectedItem is Stick s
+                && Typed.Text?.Trim() == s.Device;
+        Open.Click += (_, _) =>
+        {
+            if (Which.SelectedItem is Stick s && s.Where.Length > 0) Reveal.Show(s.Where);
+        };
+    }
+
+    public Task Load()
+    {
+        if (_loaded is { IsFaulted: true }) _loaded = null;
+        return _loaded ??= Fill();
+    }
+
+    async Task Fill()
+    {
+        var engine = Builder.Find(out var missing);
+        if (engine is null) { Found.Text = missing; Copy.IsEnabled = false; return; }
+
+        var (list, complaint) = await Inventory.Sticks(engine);
+        if (list is null)
+        {
+            Found.Text = complaint;
+            Copy.IsEnabled = false;
+            return;
+        }
+        _folder = list.Recovery;
+        _erasable = list.Erasable;
+        Which.ItemsSource = list.Sticks;
+        Which.SelectedIndex = list.Sticks.Count > 0 ? 0 : -1;
+        Copy.IsEnabled = list.Sticks.Count > 0;
+        Found.Text = list.Sticks.Count switch
+        {
+            0 => "No removable disk is plugged in. This only ever lists removable, "
+               + "external, physical disks, and never the one this computer booted "
+               + $"from{(list.Booted is { } b ? $" ({b})" : "")}.",
+            1 => "One, and it is not the disk this computer booted from.",
+            var n => $"{n} of them. The disk this computer booted from is not among "
+                   + "them and cannot be.",
+        };
+        Describe();
+    }
+
+    /// <summary>What the pane found, for the screenshot pass.</summary>
+    public async Task<string> ListForRender()
+    {
+        await Load();
+        var sticks = Which.ItemsSource as IEnumerable<Stick>;
+        var count = sticks?.Count() ?? 0;
+        return $"{count} sticks, erasable={_erasable}, into {_folder}";
+    }
+
+    void Describe()
+    {
+        if (Which.SelectedItem is not Stick stick)
+        {
+            EraseBox.IsVisible = false;
+            Open.IsVisible = false;
+            return;
+        }
+        EraseBox.IsVisible = true;
+        Open.IsVisible = stick.Where.Length > 0;
+        EraseWhat.Text = $"This erases everything on {stick.Name}, {stick.Size} "
+                       + $"({stick.Device})"
+                       + (stick.Where.Length > 0 ? $", mounted at {stick.Where}." : ".")
+                       + " There is no undoing it.";
+        EraseHow.Text = _erasable
+            ? "It becomes one FAT32 partition under GPT, which is what OpenCore "
+            + "boots from. Type the disk name to turn the button on."
+            : "This system cannot do it from here - it needs a root or "
+            + "administrator the engine does not have. Press it anyway and the "
+            + "exact commands to run yourself are printed below.";
+        EraseAsk.IsVisible = true;
+        Erase.IsEnabled = false;
+        Typed.Text = "";
+        if (!_erasable) Erase.IsEnabled = true;
+    }
+
+    async Task Pick(bool efi)
+    {
+        var top = TopLevel.GetTopLevel(this);
+        if (top is null) return;
+        var picked = await top.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = efi ? "Which EFI folder?"
+                        : $"Which folder holds {_folder}?",
+            AllowMultiple = false,
+        });
+        var path = picked.FirstOrDefault()?.TryGetLocalPath();
+        if (path is null) return;
+        if (efi) { _efi = path; EfiFrom.Text = path; }
+        else { _recovery = path; RecoveryFrom.Text = path; }
+    }
+
+    async Task CopyOn()
+    {
+        if (Which.SelectedItem is not Stick stick) return;
+        if (stick.Where.Length == 0)
+        {
+            Show("That stick is not mounted",
+                 $"{stick.Device} has no mounted volume, so there is nowhere to "
+                 + "copy to. Format it first, or mount it.", null);
+            return;
+        }
+        var engine = Builder.Find(out var missing);
+        if (engine is null) { Show("No engine", missing, null); return; }
+
+        Copy.IsEnabled = false;
+        Show($"Copying onto {stick.Name}…", "", null);
+        var said = new List<string>();
+        var (complaint, code) = await Builder.Stream(engine, line =>
+        {
+            if (line.Trim().Length == 0) return;
+            said.Add(line.TrimEnd());
+            ResultText.Text = string.Join("\n", said.TakeLast(8));
+        }, Bound, "--usb-place", stick.Where, "--out", _efi,
+           "--recovery-from", _recovery);
+        Copy.IsEnabled = true;
+
+        if (code != 0)
+        {
+            Show("Nothing was copied",
+                 complaint is { Length: > 0 } ? complaint : string.Join("\n", said), null);
+            return;
+        }
+        Show($"{stick.Name} is ready", string.Join("\n", said),
+             $"Boot the machine from it. OpenCore's picker lists macOS Base System "
+             + "if the installer is on there; the rest of macOS comes down during "
+             + "the install, so that machine needs Ethernet or a card macOS drives.");
+    }
+
+    async Task EraseIt()
+    {
+        if (Which.SelectedItem is not Stick stick) return;
+        var engine = Builder.Find(out var missing);
+        if (engine is null) { Show("No engine", missing, null); return; }
+
+        Erase.IsEnabled = false;
+        Show($"Erasing {stick.Name}…", "", null);
+        var said = new List<string>();
+        var (complaint, code) = await Builder.Stream(engine, line =>
+        {
+            if (line.Trim().Length == 0) return;
+            said.Add(line.TrimEnd());
+            ResultText.Text = string.Join("\n", said.TakeLast(8));
+        }, Bound, "--usb-prepare", stick.Device);
+
+        if (code != 0)
+        {
+            Show("It was not erased",
+                 complaint is { Length: > 0 } ? complaint : string.Join("\n", said),
+                 null);
+            Typed.Text = "";
+            return;
+        }
+        Show($"{stick.Name} is formatted", string.Join("\n", said),
+             "Now copy the EFI and the installer onto it.");
+        Typed.Text = "";
+        _loaded = null;
+        await Load();                      // it has a new mount point now
+    }
+
+    void Show(string title, string body, string? next)
+    {
+        Result.IsVisible = true;
+        ResultTitle.Text = title;
+        ResultText.Text = body;
+        ResultNext.Text = next ?? "";
+        ResultNext.IsVisible = next is not null;
+    }
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -77,8 +77,8 @@ and identity falls back to a placeholder, each with a warning.
     python3 tools/fetch_oc.py 1.0.5           # cache another OpenCore release (network)
     python3 tools/recovery.py --list          # what Apple will serve
     python3 tools/recovery.py --macos 12.7.6 --out /Volumes/USB   # fetch it (network)
-    python3 tools/usb.py --list               # removable disks, never the boot one
-    python3 tools/usb.py --place /Volumes/USB --efi build/EFI --recovery .
+    python3 tools/stick.py --list               # removable disks, never the boot one
+    python3 tools/stick.py --place /Volumes/USB --efi build/EFI --recovery .
 
 Both `extract` and `verify` take an optional Sample.plist path and otherwise use
 the vendored one. `fetch_oc.py` is how you move to a different OpenCore version:
@@ -137,12 +137,12 @@ than claiming the program never reaches the network.
 
 ## The stick
 
-`usb.py` is the only part of this repository that can destroy something, so it
+`stick.py` is the only part of this repository that can destroy something, so it
 is the one written to make that hard:
 
-    python3 tools/usb.py --list
-    python3 tools/usb.py --place /Volumes/USB --efi build/EFI --recovery .
-    python3 tools/usb.py --prepare disk4        # erases it
+    python3 tools/stick.py --list
+    python3 tools/stick.py --place /Volumes/USB --efi build/EFI --recovery .
+    python3 tools/stick.py --prepare disk4        # erases it
 
 Four rules, in the order they matter:
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -160,6 +160,19 @@ The console asks for the disk's own name to be typed, and the window does the
 same. Neither is what stops the wrong disk - the list is. The typing is so
 nobody is surprised.
 
+Whether a stick has to be formatted at all is answered from what is on it, not
+from it being a USB stick. `--list` says `ready` or `format` per disk and why:
+
+    ready   FAT32 under GPT, nothing to erase
+    ready   FAT32, but the scheme is FDisk_partition_scheme rather than GPT
+    format  this holds APFS, and OpenCore boots from a FAT32 partition
+    format  the FAT32 partition on it is not mounted
+
+A FAT32 stick under MBR boots on most firmware, so the scheme is a remark and
+not a refusal; a stick with no FAT32 on it cannot be written to at all. The
+window picks the ready one when there is one, and opens the erase panel when
+there is not.
+
 Copying is separate and destroys nothing, which is why it is a different flag:
 a stick that is already FAT32 needs no erasing. `--place` writes `EFI/` and
 `com.apple.recovery.boot/` side by side at the root and then says whether

--- a/tools/README.md
+++ b/tools/README.md
@@ -77,6 +77,8 @@ and identity falls back to a placeholder, each with a warning.
     python3 tools/fetch_oc.py 1.0.5           # cache another OpenCore release (network)
     python3 tools/recovery.py --list          # what Apple will serve
     python3 tools/recovery.py --macos 12.7.6 --out /Volumes/USB   # fetch it (network)
+    python3 tools/usb.py --list               # removable disks, never the boot one
+    python3 tools/usb.py --place /Volumes/USB --efi build/EFI --recovery .
 
 Both `extract` and `verify` take an optional Sample.plist path and otherwise use
 the vendored one. `fetch_oc.py` is how you move to a different OpenCore version:
@@ -132,6 +134,41 @@ attempt before it starts.
 This is the only thing in the repository that opens a connection on a person's
 behalf, and it does it when asked and not before. The About page says so rather
 than claiming the program never reaches the network.
+
+## The stick
+
+`usb.py` is the only part of this repository that can destroy something, so it
+is the one written to make that hard:
+
+    python3 tools/usb.py --list
+    python3 tools/usb.py --place /Volumes/USB --efi build/EFI --recovery .
+    python3 tools/usb.py --prepare disk4        # erases it
+
+Four rules, in the order they matter:
+
+  * only removable, external, physical disks are ever listed. An internal drive
+    is not behind a warning, it is not in the list,
+  * the disk this computer booted from is taken out by its own identifier -
+    `diskutil info /` on macOS, `findmnt` plus `lsblk` on Linux, the system
+    drive's disk number on Windows. Not "the first one", not "the internal one",
+  * the list is the gate. `prepare()` refuses any device the list did not
+    offer, so naming one that was never shown does nothing,
+  * and it reads the list again at the moment of erasing, because a stick can
+    be pulled out and another pushed in between being shown one and pressing.
+
+The console asks for the disk's own name to be typed, and the window does the
+same. Neither is what stops the wrong disk - the list is. The typing is so
+nobody is surprised.
+
+Copying is separate and destroys nothing, which is why it is a different flag:
+a stick that is already FAT32 needs no erasing. `--place` writes `EFI/` and
+`com.apple.recovery.boot/` side by side at the root and then says whether
+`EFI/BOOT/BOOTx64.efi` is there, because a stick without it does not boot
+whatever else was copied.
+
+Erasing works from here on macOS. On Linux it needs root and on Windows an
+administrator, and the engine has neither: it prints the exact `sgdisk`/`mkfs`
+or `diskpart` lines to run instead of failing halfway through a disk.
 
 ## The guided path
 

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -824,6 +824,11 @@ def ssdt_flow():
 def frozen_names():
     """Names a frozen build takes away, which the vendored code still uses.
 
+    And names it takes for itself: PyInstaller ships hooks for packages on
+    PyPI, and a hook fires on the module name alone. `tools/usb.py` made the
+    frozen build die inside pyusb's hook, in a traceback naming a package this
+    repository has never heard of. It is `tools/stick.py` now.
+
     PyInstaller does not run site.py, so `exit` and `quit` do not exist. SSDTTime
     quits with `exit(0)`: unfrozen that is a SystemExit and is caught, frozen it
     is a NameError that killed the whole builder the moment somebody finished
@@ -848,6 +853,24 @@ def frozen_names():
         for name, value in had.items():
             if value is not None:
                 setattr(builtins, name, value)
+
+    # a module here that shares a name with a hooked package on PyPI breaks
+    # the frozen build and nothing else, so it is invisible until a release
+    try:
+        import _pyinstaller_hooks_contrib.stdhooks as hooks
+        where = Path(hooks.__file__).parent
+    except Exception:                               # noqa: BLE001 - optional
+        where = None
+    if where is None:
+        check('PyInstaller is not here, so its hook names cannot be checked',
+              True, 'skipped')
+    else:
+        hooked = {h.stem[len('hook-'):].split('.')[0]
+                  for h in where.glob('hook-*.py')}
+        ours = {f.stem for f in Path('tools').glob('*.py')}
+        clash = sorted(ours & hooked)
+        check('no module here is named after a package PyInstaller hooks',
+              not clash, clash)
 
     # the tool must not take the builder down with it whatever it does
     src = Path('tools/acpi.py').read_text()
@@ -2224,9 +2247,9 @@ def the_stick_it_writes_to():
     checked here is the refusing: that the list is removable disks only, that
     the disk this computer booted from is not in it, and that a device the list
     did not offer cannot be erased by naming it."""
-    import usb
+    import stick
 
-    document = usb.document()
+    document = stick.document()
     check('the stick list says which system it read', document['platform'])
     check('and names what it booted from, or says it could not',
           'booted' in document)
@@ -2238,11 +2261,11 @@ def the_stick_it_writes_to():
     check('the disk this computer booted from is not offered',
           not booted or all(s['device'] != booted for s in document['sticks']),
           booted)
-    for stick in document['sticks']:
-        check(f"{stick['device']} is offered as removable", stick['removable'],
-              stick)
-        check(f"{stick['device']} says whether it can be written to as it is",
-              'ready' in stick and stick['why'], stick)
+    for found in document['sticks']:
+        check(f"{found['device']} is offered as removable", found['removable'],
+              found)
+        check(f"{found['device']} says whether it can be written to as it is",
+              'ready' in found and found['why'], found)
 
     # the question a stick raises is whether it has to be formatted, and that
     # is answered from what is on it rather than from it being a USB stick
@@ -2264,7 +2287,7 @@ def the_stick_it_writes_to():
                        'mount': ''}]}, False, 'not mounted'),
         ({'scheme': '', 'volumes': []}, False, 'FAT32'),
     ):
-        verdict, where, why = usb.verdict(case)
+        verdict, where, why = stick.verdict(case)
         check(f'{case["scheme"] or "no scheme"} + '
               f'{case["volumes"][0]["called"] if case["volumes"] else "nothing"}'
               f' -> {"ready" if ready else "format it"}',
@@ -2279,7 +2302,7 @@ def the_stick_it_writes_to():
         if any(s['device'] == made_up.removeprefix('/dev/')
                for s in document['sticks']):
             continue
-        mount, complaint = usb.prepare(made_up)
+        mount, complaint = stick.prepare(made_up)
         check(f'{made_up} is refused, not erased', mount is None and complaint,
               complaint)
 
@@ -2287,10 +2310,10 @@ def the_stick_it_writes_to():
         root = Path(where)
         # an EFI folder is one with a loader in it, not one with the right name
         (root / 'notanefi').mkdir()
-        written, complaint = usb.place(root / 'stick', efi=root / 'notanefi')
+        written, complaint = stick.place(root / 'stick', efi=root / 'notanefi')
         check('a volume that is not there is refused', complaint)
         (root / 'stick').mkdir()
-        written, complaint = usb.place(root / 'stick', efi=root / 'notanefi')
+        written, complaint = stick.place(root / 'stick', efi=root / 'notanefi')
         check('a folder with no BOOTx64.efi is not an EFI folder', complaint)
         check('and nothing was copied when it complained', not written)
 
@@ -2300,7 +2323,7 @@ def the_stick_it_writes_to():
         image = root / 'com.apple.recovery.boot'
         image.mkdir()
         (image / 'BaseSystem.dmg').write_bytes(b'not really either')
-        written, complaint = usb.place(root / 'stick', efi=root / 'EFI',
+        written, complaint = stick.place(root / 'stick', efi=root / 'EFI',
                                        recovery=root)
         check('both folders land at the root', not complaint
               and [n for n, _ in written] == ['EFI', 'com.apple.recovery.boot'],
@@ -2309,13 +2332,13 @@ def the_stick_it_writes_to():
               (root / 'stick' / 'com.apple.recovery.boot').is_dir()
               and not (root / 'stick' / 'EFI' / 'com.apple.recovery.boot').exists())
         check('and it says whether what is there would boot',
-              usb.bootable(root / 'stick'))
+              stick.bootable(root / 'stick'))
         check('a folder with no loader would not',
-              not usb.bootable(root / 'notanefi'))
+              not stick.bootable(root / 'notanefi'))
 
         # a recovery folder with nothing in it is not a recovery
         (root / 'empty').mkdir()
-        _, complaint = usb.place(root / 'stick', recovery=root / 'empty')
+        _, complaint = stick.place(root / 'stick', recovery=root / 'empty')
         check('an installer that is not there is refused', complaint)
 
     # the builder offers all three, and does none of it itself
@@ -2323,7 +2346,7 @@ def the_stick_it_writes_to():
     for flag in ('--usb-list', '--usb-place', '--usb-prepare'):
         check(f'the builder offers {flag}', f"'{flag}'" in source)
     check('and hands the work to the one tool that does it',
-          'usb.main(' in source and 'usb.document()' in source)
+          'stick.main(' in source and 'stick.document()' in source)
 
     # the window
     pane = Path('gui/Views/StickView.axaml.cs')

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -2217,6 +2217,96 @@ def the_recovery_it_can_fetch():
           'about.Network' in drawn)
 
 
+def the_stick_it_writes_to():
+    """The only part of this that can destroy something.
+
+    Everything else writes into a folder. This erases a whole disk, so what is
+    checked here is the refusing: that the list is removable disks only, that
+    the disk this computer booted from is not in it, and that a device the list
+    did not offer cannot be erased by naming it."""
+    import usb
+
+    document = usb.document()
+    check('the stick list says which system it read', document['platform'])
+    check('and names what it booted from, or says it could not',
+          'booted' in document)
+    check('and whether it can erase here at all', 'erasable' in document)
+    check('the recovery folder is the one OpenCore looks for',
+          document['recovery'] == 'com.apple.recovery.boot')
+
+    booted = document['booted']
+    check('the disk this computer booted from is not offered',
+          not booted or all(s['device'] != booted for s in document['sticks']),
+          booted)
+    for stick in document['sticks']:
+        check(f"{stick['device']} is offered as removable", stick['removable'],
+              stick)
+
+    # naming a disk nobody was offered does not erase it. This is the check
+    # that matters: the list is the gate, not the question in front of it.
+    for made_up in ('disk999', '/dev/disk999', 'sda', '0'):
+        if any(s['device'] == made_up.removeprefix('/dev/')
+               for s in document['sticks']):
+            continue
+        mount, complaint = usb.prepare(made_up)
+        check(f'{made_up} is refused, not erased', mount is None and complaint,
+              complaint)
+
+    with tempfile.TemporaryDirectory() as where:
+        root = Path(where)
+        # an EFI folder is one with a loader in it, not one with the right name
+        (root / 'notanefi').mkdir()
+        written, complaint = usb.place(root / 'stick', efi=root / 'notanefi')
+        check('a volume that is not there is refused', complaint)
+        (root / 'stick').mkdir()
+        written, complaint = usb.place(root / 'stick', efi=root / 'notanefi')
+        check('a folder with no BOOTx64.efi is not an EFI folder', complaint)
+        check('and nothing was copied when it complained', not written)
+
+        loader = root / 'EFI' / 'BOOT'
+        loader.mkdir(parents=True)
+        (loader / 'BOOTx64.efi').write_bytes(b'not really')
+        image = root / 'com.apple.recovery.boot'
+        image.mkdir()
+        (image / 'BaseSystem.dmg').write_bytes(b'not really either')
+        written, complaint = usb.place(root / 'stick', efi=root / 'EFI',
+                                       recovery=root)
+        check('both folders land at the root', not complaint
+              and [n for n, _ in written] == ['EFI', 'com.apple.recovery.boot'],
+              complaint or written)
+        check('the recovery is beside the EFI, not inside it',
+              (root / 'stick' / 'com.apple.recovery.boot').is_dir()
+              and not (root / 'stick' / 'EFI' / 'com.apple.recovery.boot').exists())
+        check('and it says whether what is there would boot',
+              usb.bootable(root / 'stick'))
+        check('a folder with no loader would not',
+              not usb.bootable(root / 'notanefi'))
+
+        # a recovery folder with nothing in it is not a recovery
+        (root / 'empty').mkdir()
+        _, complaint = usb.place(root / 'stick', recovery=root / 'empty')
+        check('an installer that is not there is refused', complaint)
+
+    # the builder offers all three, and does none of it itself
+    source = Path('tools/setup.py').read_text()
+    for flag in ('--usb-list', '--usb-place', '--usb-prepare'):
+        check(f'the builder offers {flag}', f"'{flag}'" in source)
+    check('and hands the work to the one tool that does it',
+          'usb.main(' in source and 'usb.document()' in source)
+
+    # the window
+    pane = Path('gui/Views/StickView.axaml.cs')
+    check('the window has a pane for it', pane.exists())
+    if pane.exists():
+        drawn = pane.read_text()
+        check('which reads the list from the engine', 'Inventory.Sticks' in drawn)
+        check('and asks for the disk by name before erasing',
+              'Typed.Text?.Trim() == s.Device' in drawn)
+    pass_ = Path('gui/App.axaml.cs').read_text()
+    check('the unattended pass lists and erases nothing',
+          'ListSticks' in pass_ and 'usb-prepare' not in pass_)
+
+
 def the_tools_a_window_can_drive():
     """Both vendored tools reach a person, whichever surface is attached.
 
@@ -2390,6 +2480,7 @@ if __name__ == '__main__':
                     the_vendored_opencore,
                     the_tools_a_window_can_drive,
                     the_recovery_it_can_fetch,
+                    the_stick_it_writes_to,
                     what_oclp_restores, the_about_page,
                     what_the_readme_shows):
         print(f'\n{section.__name__}')

--- a/tools/selftest.py
+++ b/tools/selftest.py
@@ -2241,6 +2241,37 @@ def the_stick_it_writes_to():
     for stick in document['sticks']:
         check(f"{stick['device']} is offered as removable", stick['removable'],
               stick)
+        check(f"{stick['device']} says whether it can be written to as it is",
+              'ready' in stick and stick['why'], stick)
+
+    # the question a stick raises is whether it has to be formatted, and that
+    # is answered from what is on it rather than from it being a USB stick
+    for case, ready, says in (
+        ({'scheme': 'GUID_partition_scheme',
+          'volumes': [{'fs': 'msdos', 'called': 'MS-DOS FAT32',
+                       'mount': '/Volumes/USB'}]}, True, 'GPT'),
+        ({'scheme': 'FDisk_partition_scheme',
+          'volumes': [{'fs': 'msdos', 'called': 'MS-DOS FAT32',
+                       'mount': '/Volumes/USB'}]}, True, 'GPT'),
+        ({'scheme': 'GUID_partition_scheme',
+          'volumes': [{'fs': 'apfs', 'called': 'APFS',
+                       'mount': '/Volumes/Mac'}]}, False, 'APFS'),
+        ({'scheme': 'GUID_partition_scheme',
+          'volumes': [{'fs': 'exfat', 'called': 'ExFAT',
+                       'mount': '/Volumes/X'}]}, False, 'ExFAT'),
+        ({'scheme': 'GUID_partition_scheme',
+          'volumes': [{'fs': 'msdos', 'called': 'MS-DOS FAT32',
+                       'mount': ''}]}, False, 'not mounted'),
+        ({'scheme': '', 'volumes': []}, False, 'FAT32'),
+    ):
+        verdict, where, why = usb.verdict(case)
+        check(f'{case["scheme"] or "no scheme"} + '
+              f'{case["volumes"][0]["called"] if case["volumes"] else "nothing"}'
+              f' -> {"ready" if ready else "format it"}',
+              verdict is ready, why)
+        check('  and it says why in those words', says in why, why)
+        check('  ready means it names where to write',
+              bool(where) is ready, where)
 
     # naming a disk nobody was offered does not erase it. This is the check
     # that matters: the list is the gate, not the question in front of it.

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -34,8 +34,8 @@ import netkexts
 import ocgen
 import inventory
 import recovery
+import stick
 import summary
-import usb
 import ui
 import usbmap
 
@@ -570,7 +570,7 @@ def main():
 
     if a.usb_list:
         import json as _json
-        sys.stdout.write(_json.dumps(usb.document(), ensure_ascii=False) + '\n')
+        sys.stdout.write(_json.dumps(stick.document(), ensure_ascii=False) + '\n')
         return 0
 
     if a.usb_place:
@@ -579,14 +579,14 @@ def main():
         argv = ['--place', a.usb_place, '--efi', a.out]
         if a.recovery_from:
             argv += ['--recovery', a.recovery_from]
-        return usb.main(argv)
+        return stick.main(argv)
 
     if a.usb_prepare:
         # --yes because the window has already asked, in front of the disk's
         # name and size. What stops the wrong disk is not the question: it is
         # that usb.prepare refuses anything --usb-list did not offer, checked
         # again at the moment it runs.
-        return usb.main(['--prepare', a.usb_prepare, '--yes'])
+        return stick.main(['--prepare', a.usb_prepare, '--yes'])
 
     if a.recovery:
         # the EFI folder's parent is the drive, which is where OpenCore looks

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -35,6 +35,7 @@ import ocgen
 import inventory
 import recovery
 import summary
+import usb
 import ui
 import usbmap
 
@@ -520,6 +521,17 @@ def main():
     ap.add_argument('--recovery-to', metavar='DIR',
                     help='the drive the recovery folder goes on, at its root '
                          '(default: the folder --out sits in)')
+    ap.add_argument('--usb-list', action='store_true',
+                    help='the removable disks an EFI could be written to, as '
+                         'JSON, and stop')
+    ap.add_argument('--usb-place', metavar='VOLUME',
+                    help='copy the EFI and the recovery onto a stick that is '
+                         'already formatted')
+    ap.add_argument('--usb-prepare', metavar='DEVICE',
+                    help='ERASE that removable disk and format it FAT32 under '
+                         'GPT; only ever a disk --usb-list offered')
+    ap.add_argument('--recovery-from', metavar='DIR',
+                    help='where com.apple.recovery.boot already is, for --usb-place')
     ap.add_argument('--describe', action='store_true',
                     help='write this machine as one JSON document and stop, for '
                          'a front end to draw')
@@ -549,12 +561,32 @@ def main():
         # acpi_tables out of this meant the frozen build looked for the dumped
         # tables inside its own unpacked copy, where they never are.
         for opt in ('machine', 'report', 'usb_map', 'acpi_tables',
-                    'recovery_to'):
+                    'recovery_to', 'usb_place', 'recovery_from'):
             if getattr(a, opt):
                 setattr(a, opt, str((started_in / getattr(a, opt)).resolve()))
 
     if a.check_tools:
         return check_tools()
+
+    if a.usb_list:
+        import json as _json
+        sys.stdout.write(_json.dumps(usb.document(), ensure_ascii=False) + '\n')
+        return 0
+
+    if a.usb_place:
+        # the same tool the console drives, so a window and a terminal put the
+        # same things in the same places
+        argv = ['--place', a.usb_place, '--efi', a.out]
+        if a.recovery_from:
+            argv += ['--recovery', a.recovery_from]
+        return usb.main(argv)
+
+    if a.usb_prepare:
+        # --yes because the window has already asked, in front of the disk's
+        # name and size. What stops the wrong disk is not the question: it is
+        # that usb.prepare refuses anything --usb-list did not offer, checked
+        # again at the moment it runs.
+        return usb.main(['--prepare', a.usb_prepare, '--yes'])
 
     if a.recovery:
         # the EFI folder's parent is the drive, which is where OpenCore looks

--- a/tools/stick.py
+++ b/tools/stick.py
@@ -16,9 +16,13 @@ is written to make that hard rather than convenient:
 Copying needs none of that and is the part most people want, so it is separate:
 a stick that is already FAT32 needs no erasing at all.
 
-    python3 tools/usb.py --list
-    python3 tools/usb.py --place /Volumes/USB --efi build/EFI --recovery .
-    python3 tools/usb.py --prepare disk4        # erases it, and says so twice
+    python3 tools/stick.py --list
+    python3 tools/stick.py --place /Volumes/USB --efi build/EFI --recovery .
+    python3 tools/stick.py --prepare disk4      # erases it, and says so twice
+
+Not called usb.py. PyInstaller ships a hook for the PyPI package of that name,
+and it fires on any module called `usb` - the frozen build died on it in CI,
+in a traceback about pyusb that has nothing to do with anything here.
 """
 import argparse
 import json

--- a/tools/usb.py
+++ b/tools/usb.py
@@ -1,0 +1,422 @@
+"""Find the USB stick, and put the EFI and the installer on it.
+
+Everything else here writes into a folder and stops. This is the only part that
+touches a whole disk, so it is the only part that can destroy something, and it
+is written to make that hard rather than convenient:
+
+  * only removable, external, physical disks are ever listed. An internal drive
+    is not "hidden" behind a warning, it is not in the list at all,
+  * the disk this computer booted from is removed from that list by its own
+    identifier, not by being assumed to be first,
+  * the list is what naming works against: a device nobody was offered cannot
+    be erased by typing it in,
+  * and the check is made again at the moment of erasing, because somebody can
+    unplug one stick and plug in another between reading and pressing.
+
+Copying needs none of that and is the part most people want, so it is separate:
+a stick that is already FAT32 needs no erasing at all.
+
+    python3 tools/usb.py --list
+    python3 tools/usb.py --place /Volumes/USB --efi build/EFI --recovery .
+    python3 tools/usb.py --prepare disk4        # erases it, and says so twice
+"""
+import argparse
+import json
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ui
+
+BOLD, DIM, GREEN, YELLOW, RED, RESET = ui.colours(
+    'bold', 'dim', 'green', 'yellow', 'red', 'reset')
+
+RECOVERY = 'com.apple.recovery.boot'
+# What OpenCore boots. A stick without this is not a boot disk, whatever else
+# is on it, so the copy checks for it rather than trusting a folder name.
+LOADER = Path('EFI') / 'BOOT' / 'BOOTx64.efi'
+
+
+def _run(*command):
+    """A command and its output, or None when it is not there to run."""
+    try:
+        done = subprocess.run(command, capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return done
+
+
+def _sizeof(count):
+    for unit in ('B', 'KB', 'MB', 'GB', 'TB'):
+        if count < 1024 or unit == 'TB':
+            return f'{count:.0f} {unit}' if unit == 'B' else f'{count:.1f} {unit}'
+        count /= 1024
+    return ''
+
+
+# --- what this computer booted from ------------------------------------------
+
+def _booted_from():
+    """The whole disk holding the running system, so it can be left out.
+
+    Named, not guessed. "the first disk" and "the internal one" are both wrong
+    on some machine somebody owns."""
+    if sys.platform == 'darwin':
+        got = _run('diskutil', 'info', '-plist', '/')
+        if got and got.returncode == 0:
+            try:
+                return plistlib.loads(got.stdout.encode()).get('ParentWholeDisk')
+            except Exception:                      # noqa: BLE001 - shape unknown
+                return None
+    if sys.platform.startswith('linux'):
+        got = _run('findmnt', '-no', 'SOURCE', '/')
+        if got and got.returncode == 0:
+            part = got.stdout.strip()
+            whole = _run('lsblk', '-no', 'PKNAME', part)
+            if whole and whole.returncode == 0 and whole.stdout.strip():
+                return whole.stdout.strip().splitlines()[0]
+    if sys.platform.startswith('win'):
+        got = _run('powershell', '-NoProfile', '-Command',
+                   '(Get-Partition -DriveLetter '
+                   '$env:SystemDrive.Substring(0,1)).DiskNumber')
+        if got and got.returncode == 0 and got.stdout.strip().isdigit():
+            return got.stdout.strip()
+    return None
+
+
+# --- the sticks ---------------------------------------------------------------
+
+def _macos_sticks():
+    """Whole disks diskutil calls external and physical, and nothing else."""
+    got = _run('diskutil', 'list', '-plist', 'external', 'physical')
+    if not got or got.returncode != 0:
+        return []
+    try:
+        listed = plistlib.loads(got.stdout.encode()).get('WholeDisks', [])
+    except Exception:                              # noqa: BLE001 - shape unknown
+        return []
+    out = []
+    for device in listed:
+        info = _run('diskutil', 'info', '-plist', f'/dev/{device}')
+        if not info or info.returncode != 0:
+            continue
+        try:
+            about = plistlib.loads(info.stdout.encode())
+        except Exception:                          # noqa: BLE001
+            continue
+        # external and physical is diskutil's answer; these two are ours, and
+        # they are what stops a Thunderbolt drive somebody works off
+        if about.get('Internal'):
+            continue
+        out.append({
+            'device': device,
+            'name': (about.get('MediaName') or '').strip() or 'unnamed',
+            'bytes': int(about.get('TotalSize') or 0),
+            'bus': about.get('BusProtocol') or '',
+            'removable': bool(about.get('Removable')
+                              or about.get('RemovableMediaOrExternalDevice')
+                              or about.get('Ejectable')),
+            'mounted': _macos_mounts(device),
+        })
+    return out
+
+
+def _macos_mounts(device):
+    got = _run('diskutil', 'list', '-plist', f'/dev/{device}')
+    if not got or got.returncode != 0:
+        return []
+    try:
+        listed = plistlib.loads(got.stdout.encode())
+    except Exception:                              # noqa: BLE001
+        return []
+    where = []
+    for disk in listed.get('AllDisksAndPartitions', []):
+        for part in disk.get('Partitions', []) or []:
+            if part.get('MountPoint'):
+                where.append(part['MountPoint'])
+    return where
+
+
+def _linux_sticks():
+    got = _run('lsblk', '-J', '-b', '-o',
+               'NAME,SIZE,RM,TRAN,MODEL,TYPE,MOUNTPOINT')
+    if not got or got.returncode != 0:
+        return []
+    try:
+        tree = json.loads(got.stdout)
+    except json.JSONDecodeError:
+        return []
+    out = []
+    for disk in tree.get('blockdevices', []):
+        if disk.get('type') != 'disk':
+            continue
+        removable = bool(disk.get('rm')) or disk.get('tran') == 'usb'
+        if not removable:
+            continue
+        mounted = [p['mountpoint'] for p in disk.get('children', []) or []
+                   if p.get('mountpoint')]
+        if disk.get('mountpoint'):
+            mounted.append(disk['mountpoint'])
+        out.append({
+            'device': disk['name'],
+            'name': (disk.get('model') or '').strip() or 'unnamed',
+            'bytes': int(disk.get('size') or 0),
+            'bus': disk.get('tran') or '',
+            'removable': removable,
+            'mounted': mounted,
+        })
+    return out
+
+
+def _windows_sticks():
+    script = ("Get-Disk | Where-Object BusType -eq 'USB' | "
+              "ForEach-Object { $d = $_; "
+              "$m = (Get-Partition -DiskNumber $d.Number -ErrorAction SilentlyContinue "
+              "| Where-Object DriveLetter | ForEach-Object { \"$($_.DriveLetter):\\\" }) "
+              "-join ','; "
+              "[pscustomobject]@{ device = \"$($d.Number)\"; "
+              "name = $d.FriendlyName; bytes = $d.Size; bus = 'USB'; "
+              "mounted = $m } } | ConvertTo-Json -AsArray")
+    got = _run('powershell', '-NoProfile', '-Command', script)
+    if not got or got.returncode != 0:
+        return []
+    try:
+        listed = json.loads(got.stdout or '[]')
+    except json.JSONDecodeError:
+        return []
+    out = []
+    for disk in listed:
+        out.append({
+            'device': str(disk.get('device')),
+            'name': (disk.get('name') or '').strip() or 'unnamed',
+            'bytes': int(disk.get('bytes') or 0),
+            'bus': 'USB',
+            'removable': True,
+            'mounted': [m for m in (disk.get('mounted') or '').split(',') if m],
+        })
+    return out
+
+
+def sticks():
+    """Every disk this may write to, with the boot disk taken out.
+
+    An empty list means no removable disk was found, which on a laptop with
+    nothing plugged in is the right answer and not a failure."""
+    finder = {'darwin': _macos_sticks}.get(sys.platform)
+    if finder is None:
+        finder = _linux_sticks if sys.platform.startswith('linux') else (
+            _windows_sticks if sys.platform.startswith('win') else None)
+    if finder is None:
+        return []
+    booted = _booted_from()
+    out = []
+    for stick in finder():
+        if booted and stick['device'] == booted:
+            continue
+        stick['size'] = _sizeof(stick['bytes'])
+        out.append(stick)
+    return sorted(out, key=lambda s: s['device'])
+
+
+def offered(device):
+    """The stick by that name, but only if it was in the list.
+
+    Read again rather than remembered: between somebody being shown a list and
+    pressing the button, a stick can be pulled out and another put in."""
+    asked = (device or '').strip().removeprefix('/dev/')
+    for stick in sticks():
+        if stick['device'] == asked:
+            return stick
+    return None
+
+
+# --- putting the folders on it -------------------------------------------------
+
+def place(volume, efi=None, recovery=None):
+    """Copy an EFI folder and a recovery folder to the root of a volume.
+
+    Returns (written, complaint). Both are optional: a stick that already has
+    one of them and needs the other is an ordinary thing."""
+    root = Path(volume).expanduser()
+    if not root.is_dir():
+        return [], f'{root} is not a folder this can write to'
+    written = []
+
+    if efi:
+        source = Path(efi).expanduser()
+        if source.name.upper() != 'EFI' and (source / 'EFI').is_dir():
+            source = source / 'EFI'          # somebody named the folder above it
+        if not (source / 'BOOT' / 'BOOTx64.efi').exists():
+            return [], (f'{source} has no BOOT/BOOTx64.efi in it, so it is not '
+                        'an EFI folder OpenCore would boot')
+        target = root / 'EFI'
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(source, target)
+        written.append(('EFI', sum(f.stat().st_size for f in target.rglob('*')
+                                   if f.is_file())))
+
+    if recovery:
+        source = Path(recovery).expanduser()
+        if source.name != RECOVERY and (source / RECOVERY).is_dir():
+            source = source / RECOVERY
+        if not any(source.glob('BaseSystem.*')):
+            return written, (f'{source} holds no BaseSystem, so there is no '
+                             'installer here to copy')
+        target = root / RECOVERY
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(source, target)
+        written.append((RECOVERY, sum(f.stat().st_size for f in target.rglob('*')
+                                      if f.is_file())))
+
+    if not written:
+        return [], 'nothing was named to copy'
+    return written, None
+
+
+def bootable(volume):
+    """Whether what is on this volume would boot, said as a fact not a hope."""
+    root = Path(volume).expanduser()
+    return (root / LOADER).exists()
+
+
+# --- erasing it ----------------------------------------------------------------
+
+def prepare(device, label='USB'):
+    """Erase a stick to one FAT32 partition under GPT. Returns (mount, complaint).
+
+    This destroys what is on it. The device has to be one `sticks()` offered at
+    the moment this runs; nothing else is accepted, and the caller having asked
+    a minute ago is not enough."""
+    stick = offered(device)
+    if stick is None:
+        return None, (f'{device} is not one of the removable disks this can '
+                      'write to, so it will not be erased')
+
+    if sys.platform == 'darwin':
+        done = _run('diskutil', 'eraseDisk', 'MS-DOS', label, 'GPT',
+                    f'/dev/{stick["device"]}')
+        if done is None or done.returncode != 0:
+            return None, _said(done)
+        return _macos_mounts(stick['device'])[:1] or [None], None
+    if sys.platform.startswith('linux'):
+        return None, ('erasing a disk needs root on Linux, and this does not ask '
+                      f'for it. Run: sudo sgdisk --zap-all /dev/{stick["device"]} '
+                      f'&& sudo sgdisk -n 1:0:0 -t 1:0700 /dev/{stick["device"]} '
+                      f'&& sudo mkfs.vfat -F 32 -n {label} /dev/{stick["device"]}1')
+    if sys.platform.startswith('win'):
+        return None, ('erasing a disk needs an administrator on Windows, and '
+                      'this is not running as one. Open diskpart as '
+                      f'administrator: select disk {stick["device"]}, clean, '
+                      'convert gpt, create partition primary, '
+                      f'format fs=fat32 quick label={label}, assign')
+    return None, f'no way to erase a disk on {sys.platform}'
+
+
+def _said(done):
+    if done is None:
+        return 'the tool that does this is not on this machine'
+    for stream in (done.stderr, done.stdout):
+        if (stream or '').strip():
+            return (stream or '').strip().splitlines()[-1]
+    return f'it exited {done.returncode}'
+
+
+def document():
+    """The list as a front end reads it, with what it is allowed to do.
+
+    `erasable` is not a guess about permissions: it is what prepare() would do
+    on this system, so a window can grey a button out instead of offering one
+    that always fails."""
+    return {
+        't': 'sticks',
+        'platform': sys.platform,
+        'booted': _booted_from(),
+        'erasable': sys.platform == 'darwin',
+        'recovery': RECOVERY,
+        'sticks': sticks(),
+    }
+
+
+# --- the console ---------------------------------------------------------------
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--list', action='store_true',
+                    help='the removable disks this could write to')
+    ap.add_argument('--place', metavar='VOLUME',
+                    help='copy onto a stick that is already formatted')
+    ap.add_argument('--efi', help='the EFI folder to copy')
+    ap.add_argument('--recovery', help='the folder holding com.apple.recovery.boot')
+    ap.add_argument('--prepare', metavar='DEVICE',
+                    help='ERASE this disk and format it FAT32 under GPT')
+    ap.add_argument('--yes', action='store_true',
+                    help='answer the erase confirmation, for scripting')
+    a = ap.parse_args(argv)
+
+    if a.prepare:
+        stick = offered(a.prepare)
+        if stick is None:
+            print(f'{YELLOW}{a.prepare} is not one of the removable disks this '
+                  f'can write to{RESET}')
+            print(f'{DIM}  --list says which are{RESET}')
+            return 1
+        print(f'{RED}{BOLD}This erases everything on it.{RESET}')
+        print(f"  {stick['device']}  {stick['name']}  {stick['size']}"
+              + (f"  mounted at {', '.join(stick['mounted'])}"
+                 if stick['mounted'] else ''))
+        if not a.yes:
+            # the name, not "y". A stick is picked out by what it says on it,
+            # and a habit of pressing y is exactly what this is guarding
+            typed = input(f"  type {stick['device']} to go ahead: ").strip()
+            if typed != stick['device']:
+                print(f'{DIM}  nothing was erased{RESET}')
+                return 1
+        mount, complaint = prepare(stick['device'])
+        if complaint:
+            print(f'{YELLOW}  {complaint}{RESET}')
+            return 1
+        print(f'{GREEN}  erased and formatted{RESET}'
+              + (f', mounted at {mount}' if mount else ''))
+        return 0
+
+    if a.place:
+        written, complaint = place(a.place, a.efi, a.recovery)
+        if complaint:
+            print(f'{YELLOW}{complaint}{RESET}')
+            return 1
+        print(f'{BOLD}Written to {a.place}{RESET}')
+        for name, size in written:
+            print(f'  {name:28} {_sizeof(size)}')
+        if bootable(a.place):
+            print(f'{GREEN}  {LOADER} is there, so this stick boots{RESET}')
+        else:
+            print(f'{YELLOW}  no {LOADER} here yet - copy the EFI folder too, '
+                  f'or this will not boot{RESET}')
+        return 0
+
+    found = sticks()
+    print(f'{BOLD}Removable disks{RESET}')
+    if not found:
+        print(f'{DIM}  none. Plug one in, or the disk you mean is not removable '
+              f'- this only ever lists removable, external, physical disks, and '
+              f'never the one this computer booted from.{RESET}')
+        return 0
+    for stick in found:
+        print(f"  {stick['device']:10} {stick['name'][:28]:30} {stick['size']:>10}"
+              f"  {DIM}{stick['bus']}{RESET}")
+        if stick['mounted']:
+            print(f"{DIM}             mounted at {', '.join(stick['mounted'])}{RESET}")
+    print(f'{DIM}\n  The disk this computer booted from is not in this list, and '
+          f'cannot be.{RESET}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/usb.py
+++ b/tools/usb.py
@@ -112,6 +112,7 @@ def _macos_sticks():
         # they are what stops a Thunderbolt drive somebody works off
         if about.get('Internal'):
             continue
+        scheme, volumes = _macos_layout(device)
         out.append({
             'device': device,
             'name': (about.get('MediaName') or '').strip() or 'unnamed',
@@ -120,30 +121,57 @@ def _macos_sticks():
             'removable': bool(about.get('Removable')
                               or about.get('RemovableMediaOrExternalDevice')
                               or about.get('Ejectable')),
-            'mounted': _macos_mounts(device),
+            'scheme': scheme,
+            'volumes': volumes,
+            'mounted': [v['mount'] for v in volumes if v['mount']],
         })
     return out
 
 
-def _macos_mounts(device):
+def _macos_layout(device):
+    """(scheme, volumes) for one whole disk.
+
+    The scheme comes off the whole disk and the filesystem off each partition,
+    because "it is a USB stick" says nothing about either: a stick out of a
+    camera is FAT32 under MBR and one out of a Mac is APFS under GPT."""
     got = _run('diskutil', 'list', '-plist', f'/dev/{device}')
     if not got or got.returncode != 0:
-        return []
+        return '', []
     try:
         listed = plistlib.loads(got.stdout.encode())
     except Exception:                              # noqa: BLE001
-        return []
-    where = []
+        return '', []
+    scheme, volumes = '', []
     for disk in listed.get('AllDisksAndPartitions', []):
+        if disk.get('DeviceIdentifier') != device:
+            continue
+        scheme = disk.get('Content') or ''
         for part in disk.get('Partitions', []) or []:
-            if part.get('MountPoint'):
-                where.append(part['MountPoint'])
-    return where
+            about = _run('diskutil', 'info', '-plist',
+                         f"/dev/{part['DeviceIdentifier']}")
+            kind, named = '', ''
+            if about and about.returncode == 0:
+                try:
+                    read = plistlib.loads(about.stdout.encode())
+                    kind = read.get('FilesystemType') or ''
+                    named = read.get('FilesystemName') or ''
+                except Exception:                  # noqa: BLE001
+                    pass
+            volumes.append({
+                'name': part.get('VolumeName') or '',
+                'fs': kind, 'called': named,
+                'mount': part.get('MountPoint') or '',
+            })
+    return scheme, volumes
+
+
+def _macos_mounts(device):
+    return [v['mount'] for v in _macos_layout(device)[1] if v['mount']]
 
 
 def _linux_sticks():
     got = _run('lsblk', '-J', '-b', '-o',
-               'NAME,SIZE,RM,TRAN,MODEL,TYPE,MOUNTPOINT')
+               'NAME,SIZE,RM,TRAN,MODEL,TYPE,MOUNTPOINT,FSTYPE,PTTYPE,LABEL')
     if not got or got.returncode != 0:
         return []
     try:
@@ -157,17 +185,23 @@ def _linux_sticks():
         removable = bool(disk.get('rm')) or disk.get('tran') == 'usb'
         if not removable:
             continue
-        mounted = [p['mountpoint'] for p in disk.get('children', []) or []
-                   if p.get('mountpoint')]
-        if disk.get('mountpoint'):
-            mounted.append(disk['mountpoint'])
+        volumes = [{'name': p.get('label') or '', 'fs': p.get('fstype') or '',
+                    'called': p.get('fstype') or '',
+                    'mount': p.get('mountpoint') or ''}
+                   for p in disk.get('children', []) or []]
+        if not volumes and disk.get('fstype'):     # formatted with no table
+            volumes = [{'name': disk.get('label') or '', 'fs': disk['fstype'],
+                        'called': disk['fstype'],
+                        'mount': disk.get('mountpoint') or ''}]
         out.append({
             'device': disk['name'],
             'name': (disk.get('model') or '').strip() or 'unnamed',
             'bytes': int(disk.get('size') or 0),
             'bus': disk.get('tran') or '',
             'removable': removable,
-            'mounted': mounted,
+            'scheme': disk.get('pttype') or '',
+            'volumes': volumes,
+            'mounted': [v['mount'] for v in volumes if v['mount']],
         })
     return out
 
@@ -175,12 +209,17 @@ def _linux_sticks():
 def _windows_sticks():
     script = ("Get-Disk | Where-Object BusType -eq 'USB' | "
               "ForEach-Object { $d = $_; "
-              "$m = (Get-Partition -DiskNumber $d.Number -ErrorAction SilentlyContinue "
-              "| Where-Object DriveLetter | ForEach-Object { \"$($_.DriveLetter):\\\" }) "
-              "-join ','; "
+              "$v = @(Get-Partition -DiskNumber $d.Number -ErrorAction SilentlyContinue "
+              "| Where-Object DriveLetter | ForEach-Object { "
+              "$vol = Get-Volume -DriveLetter $_.DriveLetter "
+              "-ErrorAction SilentlyContinue; "
+              "[pscustomobject]@{ name = $vol.FileSystemLabel; "
+              "fs = $vol.FileSystem; called = $vol.FileSystem; "
+              "mount = \"$($_.DriveLetter):\\\" } }); "
               "[pscustomobject]@{ device = \"$($d.Number)\"; "
               "name = $d.FriendlyName; bytes = $d.Size; bus = 'USB'; "
-              "mounted = $m } } | ConvertTo-Json -AsArray")
+              "scheme = \"$($d.PartitionStyle)\"; "
+              "volumes = $v } } | ConvertTo-Json -Depth 4 -AsArray")
     got = _run('powershell', '-NoProfile', '-Command', script)
     if not got or got.returncode != 0:
         return []
@@ -190,15 +229,56 @@ def _windows_sticks():
         return []
     out = []
     for disk in listed:
+        volumes = [{'name': v.get('name') or '', 'fs': (v.get('fs') or '').lower(),
+                    'called': v.get('called') or '', 'mount': v.get('mount') or ''}
+                   for v in (disk.get('volumes') or [])]
         out.append({
             'device': str(disk.get('device')),
             'name': (disk.get('name') or '').strip() or 'unnamed',
             'bytes': int(disk.get('bytes') or 0),
             'bus': 'USB',
             'removable': True,
-            'mounted': [m for m in (disk.get('mounted') or '').split(',') if m],
+            'scheme': disk.get('scheme') or '',
+            'volumes': volumes,
+            'mounted': [v['mount'] for v in volumes if v['mount']],
         })
     return out
+
+
+# What FAT32 is called by the three things that report it. OpenCore's loader
+# lives on a FAT partition; nothing else on a stick can hold it.
+FAT = {'msdos', 'vfat', 'fat32', 'fat'}
+# and the scheme the guide expects. A FAT32 stick under MBR boots on most
+# firmware, so this is a remark rather than a refusal.
+GPT = {'guid_partition_scheme', 'gpt'}
+
+
+def verdict(stick):
+    """Whether this stick can be written to as it stands, and why.
+
+    The question people actually have is "do I need to format this?", and the
+    answer is not "it is a USB stick". A stick out of a camera is FAT32 under
+    MBR; one out of a Mac is APFS under GPT; a new one is exFAT. Only the first
+    can be copied to without erasing anything."""
+    fat = [v for v in stick.get('volumes', [])
+           if (v.get('fs') or '').lower() in FAT]
+    gpt = (stick.get('scheme') or '').lower() in GPT
+    named = ', '.join(sorted({(v.get('called') or v.get('fs') or 'unformatted')
+                              for v in stick.get('volumes', [])})) or 'nothing'
+
+    if not fat:
+        return False, '', (f'this holds {named}, and OpenCore boots from a FAT32 '
+                           f'partition. It has to be erased and formatted first.')
+    mounted = [v for v in fat if v.get('mount')]
+    if not mounted:
+        return False, '', ('the FAT32 partition on it is not mounted, so there is '
+                           'nowhere to copy to. Mount it, or format the stick.')
+    where = mounted[0]['mount']
+    if gpt:
+        return True, where, 'FAT32 under GPT: ready as it is, nothing to erase.'
+    return True, where, (f"FAT32, so this can be written to - though the "
+                         f"partition scheme is {stick.get('scheme') or 'unknown'} "
+                         f"rather than GPT, which is what the guide expects.")
 
 
 def sticks():
@@ -218,6 +298,7 @@ def sticks():
         if booted and stick['device'] == booted:
             continue
         stick['size'] = _sizeof(stick['bytes'])
+        stick['ready'], stick['write_to'], stick['why'] = verdict(stick)
         out.append(stick)
     return sorted(out, key=lambda s: s['device'])
 
@@ -409,10 +490,12 @@ def main(argv=None):
               f'never the one this computer booted from.{RESET}')
         return 0
     for stick in found:
+        mark = f'{GREEN}ready{RESET}' if stick['ready'] else f'{YELLOW}format{RESET}'
         print(f"  {stick['device']:10} {stick['name'][:28]:30} {stick['size']:>10}"
-              f"  {DIM}{stick['bus']}{RESET}")
-        if stick['mounted']:
-            print(f"{DIM}             mounted at {', '.join(stick['mounted'])}{RESET}")
+              f"  {mark}")
+        print(f"{DIM}             {stick['why']}{RESET}")
+        if stick['write_to']:
+            print(f"{DIM}             write to {stick['write_to']}{RESET}")
     print(f'{DIM}\n  The disk this computer booted from is not in this list, and '
           f'cannot be.{RESET}')
     return 0


### PR DESCRIPTION
Everything else here writes into a folder. This erases a whole disk, so most of
it is the refusing:

- only removable, external, physical disks are listed. An internal drive is not
  behind a warning, it is not in the list,
- the disk this computer booted from is taken out by its own identifier —
  `diskutil info /`, `findmnt` + `lsblk`, the system drive's disk number,
- the list is the gate. `prepare()` refuses any device the list did not offer,
  and reads the list again at the moment of erasing, because a stick can be
  swapped between being shown one and pressing,
- the console asks for the disk's own name to be typed and the window does the
  same. Neither is what stops the wrong disk; the list is.

Copying is separate and destroys nothing: `--place` writes `EFI/` and
`com.apple.recovery.boot/` side by side at the root and then says whether
`EFI/BOOT/BOOTx64.efi` is there, because a stick without it does not boot
whatever else was copied.

Erasing works on macOS. Linux needs root and Windows an administrator, which
the engine is not — it prints the exact `sgdisk`/`diskpart` lines instead of
failing halfway through a disk.

A new pane, eighth, under Recovery. The render pass lists and writes nothing.

Also adds `gui/bin/` and `gui/obj/` to .gitignore: a `git add -A` swept the
916 MB BaseSystem.dmg that `dotnet build` leaves beside the binary into a
commit, which is why the last few pushes hung.